### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/101/751/659/101751659.geojson
+++ b/data/101/751/659/101751659.geojson
@@ -704,6 +704,9 @@
         "wd:id":"Q1435"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"94a86a1dcadec0478dcd17c1835654bd",
     "wof:hierarchy":[
         {
@@ -717,7 +720,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647399,
+    "wof:lastmodified":1582318749,
     "wof:megacity":0,
     "wof:name":"Zagreb",
     "wof:parent_id":85684811,

--- a/data/101/751/767/101751767.geojson
+++ b/data/101/751/767/101751767.geojson
@@ -453,6 +453,9 @@
         "wd:id":"Q1663"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5de10070e3d1e82c7be6bd7d5763478b",
     "wof:hierarchy":[
         {
@@ -466,7 +469,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647400,
+    "wof:lastmodified":1582318750,
     "wof:name":"Split",
     "wof:parent_id":85684781,
     "wof:placetype":"locality",

--- a/data/101/751/769/101751769.geojson
+++ b/data/101/751/769/101751769.geojson
@@ -418,6 +418,9 @@
         "qs_pg:id":1043867
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"71b14c6aac09e6e493b5b7d451427145",
     "wof:hierarchy":[
         {
@@ -428,7 +431,7 @@
         }
     ],
     "wof:id":101751769,
-    "wof:lastmodified":1566647400,
+    "wof:lastmodified":1582318750,
     "wof:name":"Zadar",
     "wof:parent_id":85684807,
     "wof:placetype":"locality",

--- a/data/101/751/771/101751771.geojson
+++ b/data/101/751/771/101751771.geojson
@@ -425,6 +425,9 @@
         "wk:page":"Pula"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8b5dcae107d5ae9963fb3ecae0b3e89a",
     "wof:hierarchy":[
         {
@@ -438,7 +441,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647400,
+    "wof:lastmodified":1582318749,
     "wof:name":"Pula",
     "wof:parent_id":85684829,
     "wof:placetype":"locality",

--- a/data/101/751/773/101751773.geojson
+++ b/data/101/751/773/101751773.geojson
@@ -361,6 +361,9 @@
         "wd:id":"Q4686"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"83582399b4153fa7d9dd69eaee645e82",
     "wof:hierarchy":[
         {
@@ -374,7 +377,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647401,
+    "wof:lastmodified":1582318750,
     "wof:name":"Slavonski Brod",
     "wof:parent_id":85684749,
     "wof:placetype":"locality",

--- a/data/101/751/775/101751775.geojson
+++ b/data/101/751/775/101751775.geojson
@@ -448,6 +448,9 @@
         "wd:id":"Q1647"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"641d417616fa22459e27ed86aa0d8254",
     "wof:hierarchy":[
         {
@@ -458,7 +461,7 @@
         }
     ],
     "wof:id":101751775,
-    "wof:lastmodified":1566647401,
+    "wof:lastmodified":1582318750,
     "wof:name":"Rijeka",
     "wof:parent_id":85684789,
     "wof:placetype":"locality",

--- a/data/101/751/779/101751779.geojson
+++ b/data/101/751/779/101751779.geojson
@@ -421,6 +421,9 @@
         "wd:id":"Q1640"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"98e97a03d987e8bb49831095f65ebb31",
     "wof:hierarchy":[
         {
@@ -434,7 +437,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647400,
+    "wof:lastmodified":1582318749,
     "wof:name":"Osijek",
     "wof:parent_id":85684805,
     "wof:placetype":"locality",

--- a/data/101/754/497/101754497.geojson
+++ b/data/101/754/497/101754497.geojson
@@ -118,6 +118,9 @@
         "qs_pg:id":892227
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d000db2b824ccfb07ee3cfc199e6141c",
     "wof:hierarchy":[
         {
@@ -128,7 +131,7 @@
         }
     ],
     "wof:id":101754497,
-    "wof:lastmodified":1566647336,
+    "wof:lastmodified":1582318740,
     "wof:name":"Bibinje",
     "wof:parent_id":85684807,
     "wof:placetype":"locality",

--- a/data/101/754/499/101754499.geojson
+++ b/data/101/754/499/101754499.geojson
@@ -114,6 +114,9 @@
         "qs_pg:id":581933
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a83069de1dbaa41f9bec0c52b2d6ed04",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":101754499,
-    "wof:lastmodified":1566647337,
+    "wof:lastmodified":1582318740,
     "wof:name":"Suko\u0161an",
     "wof:parent_id":85684807,
     "wof:placetype":"locality",

--- a/data/101/754/503/101754503.geojson
+++ b/data/101/754/503/101754503.geojson
@@ -103,6 +103,9 @@
         "wd:id":"Q3304419"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9ecd2c73aef7b6b8ee5acac7f48e0bc1",
     "wof:hierarchy":[
         {
@@ -113,7 +116,7 @@
         }
     ],
     "wof:id":101754503,
-    "wof:lastmodified":1566647336,
+    "wof:lastmodified":1582318740,
     "wof:name":"Podvinje",
     "wof:parent_id":85684749,
     "wof:placetype":"locality",

--- a/data/101/754/511/101754511.geojson
+++ b/data/101/754/511/101754511.geojson
@@ -121,6 +121,9 @@
         "wd:id":"Q1017892"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1d53594d4053b5e4c6f45c81495d6fd7",
     "wof:hierarchy":[
         {
@@ -131,7 +134,7 @@
         }
     ],
     "wof:id":101754511,
-    "wof:lastmodified":1566647337,
+    "wof:lastmodified":1582318740,
     "wof:name":"Sesvete",
     "wof:parent_id":85684811,
     "wof:placetype":"locality",

--- a/data/101/758/555/101758555.geojson
+++ b/data/101/758/555/101758555.geojson
@@ -115,6 +115,9 @@
         "wk:page":"Ka\u0161tel \u0160tafili\u0107"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f1a94d950ec753be2f88f3a3b49c149c",
     "wof:hierarchy":[
         {
@@ -125,7 +128,7 @@
         }
     ],
     "wof:id":101758555,
-    "wof:lastmodified":1566647389,
+    "wof:lastmodified":1582318748,
     "wof:name":"Ka\u0161tel \u0160tafili\u0107",
     "wof:parent_id":85684781,
     "wof:placetype":"locality",

--- a/data/101/758/561/101758561.geojson
+++ b/data/101/758/561/101758561.geojson
@@ -112,6 +112,9 @@
         "wk:page":"Ka\u0161tel Luk\u0161i\u0107"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6928f618a096390a56f011c1fdbb0d7d",
     "wof:hierarchy":[
         {
@@ -122,7 +125,7 @@
         }
     ],
     "wof:id":101758561,
-    "wof:lastmodified":1566647388,
+    "wof:lastmodified":1582318747,
     "wof:name":"Ka\u0161tel Luk\u0161i\u0107",
     "wof:parent_id":85684781,
     "wof:placetype":"locality",

--- a/data/101/758/569/101758569.geojson
+++ b/data/101/758/569/101758569.geojson
@@ -114,6 +114,9 @@
         "wk:page":"Ka\u0161tel Su\u0107urac"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3ab0f968bdc7c9f707d9951ba51bcd94",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":101758569,
-    "wof:lastmodified":1566647387,
+    "wof:lastmodified":1582318747,
     "wof:name":"Ka\u0161tel Su\u0107urac",
     "wof:parent_id":85684781,
     "wof:placetype":"locality",

--- a/data/101/758/571/101758571.geojson
+++ b/data/101/758/571/101758571.geojson
@@ -95,6 +95,9 @@
         "wk:page":"Vranjic"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"547519d3f1225da8ddb082cb3210e7a8",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
         }
     ],
     "wof:id":101758571,
-    "wof:lastmodified":1566647390,
+    "wof:lastmodified":1582318748,
     "wof:name":"Vranjic",
     "wof:parent_id":85684781,
     "wof:placetype":"locality",

--- a/data/101/758/573/101758573.geojson
+++ b/data/101/758/573/101758573.geojson
@@ -316,6 +316,9 @@
         "wd:id":"Q7028"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2a11c5bb1fa5a828f8aa2d072116f01b",
     "wof:hierarchy":[
         {
@@ -326,7 +329,7 @@
         }
     ],
     "wof:id":101758573,
-    "wof:lastmodified":1566647389,
+    "wof:lastmodified":1582318748,
     "wof:name":"Kamen",
     "wof:parent_id":85684781,
     "wof:placetype":"locality",

--- a/data/101/758/575/101758575.geojson
+++ b/data/101/758/575/101758575.geojson
@@ -184,6 +184,9 @@
         "wk:page":"Solin"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0da72406b57ec9c55e2fdfca37f3ff87",
     "wof:hierarchy":[
         {
@@ -197,7 +200,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647388,
+    "wof:lastmodified":1582318747,
     "wof:name":"Solin",
     "wof:parent_id":85684781,
     "wof:placetype":"locality",

--- a/data/101/758/577/101758577.geojson
+++ b/data/101/758/577/101758577.geojson
@@ -105,6 +105,9 @@
         "wk:page":"Sibinj"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"34f38a5b7bd85a5da2bc1440d0301540",
     "wof:hierarchy":[
         {
@@ -118,7 +121,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647390,
+    "wof:lastmodified":1582318748,
     "wof:name":"Sibinj",
     "wof:parent_id":85684749,
     "wof:placetype":"locality",

--- a/data/101/758/579/101758579.geojson
+++ b/data/101/758/579/101758579.geojson
@@ -123,6 +123,9 @@
         "qs_pg:id":1284858
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0392c88d3c709659eef694391e048526",
     "wof:hierarchy":[
         {
@@ -136,7 +139,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647390,
+    "wof:lastmodified":1582318748,
     "wof:name":"\u010cavle",
     "wof:parent_id":85684789,
     "wof:placetype":"locality",

--- a/data/101/758/585/101758585.geojson
+++ b/data/101/758/585/101758585.geojson
@@ -92,6 +92,9 @@
         "wk:page":"Mar\u010delji"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"acb8c6dc2eafc79b898e0e327e23fc32",
     "wof:hierarchy":[
         {
@@ -102,7 +105,7 @@
         }
     ],
     "wof:id":101758585,
-    "wof:lastmodified":1566647390,
+    "wof:lastmodified":1582318748,
     "wof:name":"Mar\u010delji",
     "wof:parent_id":85684789,
     "wof:placetype":"locality",

--- a/data/101/758/587/101758587.geojson
+++ b/data/101/758/587/101758587.geojson
@@ -127,6 +127,9 @@
         "wk:page":"Matulji"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e2816d2a229e71a682d446befcd91735",
     "wof:hierarchy":[
         {
@@ -140,7 +143,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647389,
+    "wof:lastmodified":1582318748,
     "wof:name":"Matulji",
     "wof:parent_id":85684789,
     "wof:placetype":"locality",

--- a/data/101/758/591/101758591.geojson
+++ b/data/101/758/591/101758591.geojson
@@ -135,6 +135,9 @@
         "wd:id":"Q399425"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0f1034a9d64d31275faa608336fb3f9e",
     "wof:hierarchy":[
         {
@@ -145,7 +148,7 @@
         }
     ],
     "wof:id":101758591,
-    "wof:lastmodified":1566647390,
+    "wof:lastmodified":1582318748,
     "wof:name":"Rube\u0161i",
     "wof:parent_id":85684789,
     "wof:placetype":"locality",

--- a/data/101/758/593/101758593.geojson
+++ b/data/101/758/593/101758593.geojson
@@ -200,6 +200,9 @@
         "wd:id":"Q223353"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"db86fb139b87c6d7943627ddc6dd772c",
     "wof:hierarchy":[
         {
@@ -213,7 +216,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647388,
+    "wof:lastmodified":1582318747,
     "wof:name":"Opatija",
     "wof:parent_id":85684789,
     "wof:placetype":"locality",

--- a/data/101/758/597/101758597.geojson
+++ b/data/101/758/597/101758597.geojson
@@ -89,6 +89,9 @@
         "wk:page":"Josipovac"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"94f73f7970938b3fb19db9382e37ef34",
     "wof:hierarchy":[
         {
@@ -99,7 +102,7 @@
         }
     ],
     "wof:id":101758597,
-    "wof:lastmodified":1566647389,
+    "wof:lastmodified":1582318748,
     "wof:name":"Josipovac",
     "wof:parent_id":85684805,
     "wof:placetype":"locality",

--- a/data/101/760/467/101760467.geojson
+++ b/data/101/760/467/101760467.geojson
@@ -138,6 +138,9 @@
         "wk:page":"Klis"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"335407f25c46cea89e567975e9016fd0",
     "wof:hierarchy":[
         {
@@ -151,7 +154,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647399,
+    "wof:lastmodified":1582318749,
     "wof:name":"Klis",
     "wof:parent_id":85684781,
     "wof:placetype":"locality",

--- a/data/101/760/469/101760469.geojson
+++ b/data/101/760/469/101760469.geojson
@@ -143,6 +143,9 @@
         "wk:page":"Kastav"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"764b6f1b59ddb9acfa8dabbfb4980ae0",
     "wof:hierarchy":[
         {
@@ -156,7 +159,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647399,
+    "wof:lastmodified":1582318749,
     "wof:name":"Kastav",
     "wof:parent_id":85684789,
     "wof:placetype":"locality",

--- a/data/101/785/785/101785785.geojson
+++ b/data/101/785/785/101785785.geojson
@@ -169,6 +169,9 @@
         "wk:page":"Beli Manastir"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"31f681cd5752a75ffdf333c39d5b2ca3",
     "wof:hierarchy":[
         {
@@ -182,7 +185,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647377,
+    "wof:lastmodified":1582318746,
     "wof:name":"Beli Manastir",
     "wof:parent_id":85684805,
     "wof:placetype":"locality",

--- a/data/101/790/165/101790165.geojson
+++ b/data/101/790/165/101790165.geojson
@@ -137,6 +137,9 @@
         "wk:page":"Podturen"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"39e6f49d8b6ff0bf10cab07f139da08b",
     "wof:hierarchy":[
         {
@@ -147,7 +150,7 @@
         }
     ],
     "wof:id":101790165,
-    "wof:lastmodified":1566647335,
+    "wof:lastmodified":1582318740,
     "wof:name":"Podturen",
     "wof:parent_id":85684823,
     "wof:placetype":"locality",

--- a/data/101/790/167/101790167.geojson
+++ b/data/101/790/167/101790167.geojson
@@ -107,6 +107,9 @@
         "wk:page":"Orehovica, Croatia"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"44dcdde62d5c74f240a23b0f3c5a0110",
     "wof:hierarchy":[
         {
@@ -117,7 +120,7 @@
         }
     ],
     "wof:id":101790167,
-    "wof:lastmodified":1566647334,
+    "wof:lastmodified":1582318740,
     "wof:name":"Orehovica",
     "wof:parent_id":85684823,
     "wof:placetype":"locality",

--- a/data/101/790/169/101790169.geojson
+++ b/data/101/790/169/101790169.geojson
@@ -95,6 +95,9 @@
         "wk:page":"Peklenica"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2982d0ee45cee7aa0ed116528468d9df",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
         }
     ],
     "wof:id":101790169,
-    "wof:lastmodified":1566647334,
+    "wof:lastmodified":1582318740,
     "wof:name":"Peklenica",
     "wof:parent_id":85684823,
     "wof:placetype":"locality",

--- a/data/101/790/173/101790173.geojson
+++ b/data/101/790/173/101790173.geojson
@@ -111,6 +111,9 @@
         "qs_pg:id":1275516
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b3ead4c1cacb9b01909d2d65136e1990",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":101790173,
-    "wof:lastmodified":1566647334,
+    "wof:lastmodified":1582318740,
     "wof:name":"Selnica",
     "wof:parent_id":85684823,
     "wof:placetype":"locality",

--- a/data/101/790/185/101790185.geojson
+++ b/data/101/790/185/101790185.geojson
@@ -110,6 +110,9 @@
         "wk:page":"Doma\u0161inec"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"bf6082e94802462bcddfeb51066cdd18",
     "wof:hierarchy":[
         {
@@ -120,7 +123,7 @@
         }
     ],
     "wof:id":101790185,
-    "wof:lastmodified":1566647336,
+    "wof:lastmodified":1582318740,
     "wof:name":"Doma\u0161inec",
     "wof:parent_id":85684823,
     "wof:placetype":"locality",

--- a/data/101/790/187/101790187.geojson
+++ b/data/101/790/187/101790187.geojson
@@ -151,6 +151,9 @@
         "wk:page":"Prelog, Croatia"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"fad0b1e9afafe587f914ee2f19d66da7",
     "wof:hierarchy":[
         {
@@ -161,7 +164,7 @@
         }
     ],
     "wof:id":101790187,
-    "wof:lastmodified":1566647334,
+    "wof:lastmodified":1582318740,
     "wof:name":"Prelog",
     "wof:parent_id":85684823,
     "wof:placetype":"locality",

--- a/data/101/790/191/101790191.geojson
+++ b/data/101/790/191/101790191.geojson
@@ -116,6 +116,9 @@
         "wk:page":"Gori\u010dan"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"70871f5b0053f208c47e1dcad2e59db9",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":101790191,
-    "wof:lastmodified":1566647335,
+    "wof:lastmodified":1582318740,
     "wof:name":"Gori\u010dan",
     "wof:parent_id":85684823,
     "wof:placetype":"locality",

--- a/data/101/790/193/101790193.geojson
+++ b/data/101/790/193/101790193.geojson
@@ -119,6 +119,9 @@
         "wk:page":"Kotoriba"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9633f77cff0241201865fc5af44c96a7",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
         }
     ],
     "wof:id":101790193,
-    "wof:lastmodified":1566647334,
+    "wof:lastmodified":1582318740,
     "wof:name":"Kotoriba",
     "wof:parent_id":85684823,
     "wof:placetype":"locality",

--- a/data/101/791/213/101791213.geojson
+++ b/data/101/791/213/101791213.geojson
@@ -128,6 +128,9 @@
         "wk:page":"Pitoma\u010da"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"80c0620803a48c13fd26a8e04395afd6",
     "wof:hierarchy":[
         {
@@ -138,7 +141,7 @@
         }
     ],
     "wof:id":101791213,
-    "wof:lastmodified":1566647344,
+    "wof:lastmodified":1582318741,
     "wof:name":"Pitoma\u010da",
     "wof:parent_id":85684793,
     "wof:placetype":"locality",

--- a/data/101/791/221/101791221.geojson
+++ b/data/101/791/221/101791221.geojson
@@ -113,6 +113,9 @@
         "wk:page":"Batina"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"29440ec4d73a33697e4bec6786e4c1f8",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
         }
     ],
     "wof:id":101791221,
-    "wof:lastmodified":1566647339,
+    "wof:lastmodified":1582318740,
     "wof:name":"Batina",
     "wof:parent_id":85684805,
     "wof:placetype":"locality",

--- a/data/101/791/225/101791225.geojson
+++ b/data/101/791/225/101791225.geojson
@@ -147,6 +147,9 @@
         "qs_pg:id":1286779
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"656b0ae1bee80358d799528016d89305",
     "wof:hierarchy":[
         {
@@ -160,7 +163,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647344,
+    "wof:lastmodified":1582318741,
     "wof:name":"Veliko Trgovi\u0161\u0107e",
     "wof:parent_id":85684813,
     "wof:placetype":"locality",

--- a/data/101/791/227/101791227.geojson
+++ b/data/101/791/227/101791227.geojson
@@ -155,6 +155,9 @@
         "wd:id":"Q139018"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2341eed3691b4ab416f5e6724e933ca1",
     "wof:hierarchy":[
         {
@@ -168,7 +171,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647339,
+    "wof:lastmodified":1582318740,
     "wof:name":"Zabok",
     "wof:parent_id":85684813,
     "wof:placetype":"locality",

--- a/data/101/791/229/101791229.geojson
+++ b/data/101/791/229/101791229.geojson
@@ -123,6 +123,9 @@
         "wk:page":"Bedekov\u010dina"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2738c813ca2b91960e7405d49f04bdce",
     "wof:hierarchy":[
         {
@@ -136,7 +139,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647338,
+    "wof:lastmodified":1582318740,
     "wof:name":"Bedekov\u010dina",
     "wof:parent_id":85684813,
     "wof:placetype":"locality",

--- a/data/101/791/231/101791231.geojson
+++ b/data/101/791/231/101791231.geojson
@@ -131,6 +131,9 @@
         "wk:page":"Zlatar, Croatia"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f3844e3062333a886f2d56a3753d02a2",
     "wof:hierarchy":[
         {
@@ -141,7 +144,7 @@
         }
     ],
     "wof:id":101791231,
-    "wof:lastmodified":1566647344,
+    "wof:lastmodified":1582318741,
     "wof:name":"Zlatar",
     "wof:parent_id":85684813,
     "wof:placetype":"locality",

--- a/data/101/791/235/101791235.geojson
+++ b/data/101/791/235/101791235.geojson
@@ -200,6 +200,9 @@
         "wd:id":"Q221189"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b69ff92334dc7bb508eaad637c09cba5",
     "wof:hierarchy":[
         {
@@ -213,7 +216,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647341,
+    "wof:lastmodified":1582318740,
     "wof:name":"Krapina",
     "wof:parent_id":85684813,
     "wof:placetype":"locality",

--- a/data/101/791/243/101791243.geojson
+++ b/data/101/791/243/101791243.geojson
@@ -126,6 +126,9 @@
         "wk:page":"Marija Bistrica"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0e4aacfba42875003bae7cbcf6bbbdf5",
     "wof:hierarchy":[
         {
@@ -139,7 +142,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647340,
+    "wof:lastmodified":1582318740,
     "wof:name":"Marija Bistrica",
     "wof:parent_id":85684813,
     "wof:placetype":"locality",

--- a/data/101/791/245/101791245.geojson
+++ b/data/101/791/245/101791245.geojson
@@ -126,6 +126,9 @@
         "wk:page":"Legrad"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"215673d278af027909a2d41dc7b4a036",
     "wof:hierarchy":[
         {
@@ -139,7 +142,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647339,
+    "wof:lastmodified":1582318740,
     "wof:name":"Legrad",
     "wof:parent_id":85684799,
     "wof:placetype":"locality",

--- a/data/101/791/249/101791249.geojson
+++ b/data/101/791/249/101791249.geojson
@@ -111,6 +111,9 @@
         "wk:page":"Peteranec"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a40db65d10d5c6e19adafb8c649953b7",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647343,
+    "wof:lastmodified":1582318741,
     "wof:name":"Peteranec",
     "wof:parent_id":85684799,
     "wof:placetype":"locality",

--- a/data/101/791/253/101791253.geojson
+++ b/data/101/791/253/101791253.geojson
@@ -97,6 +97,9 @@
         "wd:id":"Q1247234"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7eee406ad3f98d898cffb0bf78ead515",
     "wof:hierarchy":[
         {
@@ -107,7 +110,7 @@
         }
     ],
     "wof:id":101791253,
-    "wof:lastmodified":1566647344,
+    "wof:lastmodified":1582318741,
     "wof:name":"Reka",
     "wof:parent_id":85684799,
     "wof:placetype":"locality",

--- a/data/101/791/255/101791255.geojson
+++ b/data/101/791/255/101791255.geojson
@@ -112,6 +112,9 @@
         "wk:page":"Drnje"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"59d6ef462d7e9dc61ba936801fbf8026",
     "wof:hierarchy":[
         {
@@ -125,7 +128,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647346,
+    "wof:lastmodified":1582318741,
     "wof:name":"Drnje",
     "wof:parent_id":85684799,
     "wof:placetype":"locality",

--- a/data/101/791/259/101791259.geojson
+++ b/data/101/791/259/101791259.geojson
@@ -117,6 +117,9 @@
         "wk:page":"Hlebine"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"fa1a7857f21c95f6c693f9958c22250b",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647340,
+    "wof:lastmodified":1582318740,
     "wof:name":"Hlebine",
     "wof:parent_id":85684799,
     "wof:placetype":"locality",

--- a/data/101/791/265/101791265.geojson
+++ b/data/101/791/265/101791265.geojson
@@ -111,6 +111,9 @@
         "wk:page":"Molve"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ef122bd9da931b8f21aae5ad31c8a75d",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647345,
+    "wof:lastmodified":1582318741,
     "wof:name":"Molve",
     "wof:parent_id":85684799,
     "wof:placetype":"locality",

--- a/data/101/791/267/101791267.geojson
+++ b/data/101/791/267/101791267.geojson
@@ -114,6 +114,9 @@
         "wk:page":"Virje"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"155d58d1a6ba0163d90c7fd6ad032ece",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647341,
+    "wof:lastmodified":1582318741,
     "wof:name":"Virje",
     "wof:parent_id":85684799,
     "wof:placetype":"locality",

--- a/data/101/791/275/101791275.geojson
+++ b/data/101/791/275/101791275.geojson
@@ -111,6 +111,9 @@
         "wk:page":"Ferdinandovac"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ec77283eefd00cef98b62b75648de24d",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647340,
+    "wof:lastmodified":1582318740,
     "wof:name":"Ferdinandovac",
     "wof:parent_id":85684799,
     "wof:placetype":"locality",

--- a/data/101/791/283/101791283.geojson
+++ b/data/101/791/283/101791283.geojson
@@ -173,6 +173,9 @@
         "wd:id":"Q5718"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9fc698f206f716a23ae2cd8bc3f105f7",
     "wof:hierarchy":[
         {
@@ -186,7 +189,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647342,
+    "wof:lastmodified":1582318741,
     "wof:name":"Kri\u017eevci",
     "wof:parent_id":85684799,
     "wof:placetype":"locality",

--- a/data/101/791/285/101791285.geojson
+++ b/data/101/791/285/101791285.geojson
@@ -143,6 +143,9 @@
         "wk:page":"Ivanec"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"de7af861102e32654f2b3ce96834f2b7",
     "wof:hierarchy":[
         {
@@ -156,7 +159,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647343,
+    "wof:lastmodified":1582318741,
     "wof:name":"Ivanec",
     "wof:parent_id":85684835,
     "wof:placetype":"locality",

--- a/data/101/791/289/101791289.geojson
+++ b/data/101/791/289/101791289.geojson
@@ -148,6 +148,9 @@
         "wk:page":"Lepoglava"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"aa2af172e3930a2d522c4520d936f2ce",
     "wof:hierarchy":[
         {
@@ -161,7 +164,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647339,
+    "wof:lastmodified":1582318740,
     "wof:name":"Lepoglava",
     "wof:parent_id":85684835,
     "wof:placetype":"locality",

--- a/data/101/791/291/101791291.geojson
+++ b/data/101/791/291/101791291.geojson
@@ -95,6 +95,9 @@
         "wk:page":"Tu\u017eno"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d8a362523c4d67b65fdd62f07727d2d5",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
         }
     ],
     "wof:id":101791291,
-    "wof:lastmodified":1566647345,
+    "wof:lastmodified":1582318741,
     "wof:name":"Tu\u017eno",
     "wof:parent_id":85684835,
     "wof:placetype":"locality",

--- a/data/101/791/293/101791293.geojson
+++ b/data/101/791/293/101791293.geojson
@@ -114,6 +114,9 @@
         "wk:page":"Beretinec"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"295d1443e5cb4fa22ca3b1f99001d090",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647341,
+    "wof:lastmodified":1582318741,
     "wof:name":"Beretinec",
     "wof:parent_id":85684835,
     "wof:placetype":"locality",

--- a/data/101/791/297/101791297.geojson
+++ b/data/101/791/297/101791297.geojson
@@ -89,6 +89,9 @@
         "wk:page":"Nedeljanec"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"20bdb55d6c7a83ca938f34033bffb372",
     "wof:hierarchy":[
         {
@@ -99,7 +102,7 @@
         }
     ],
     "wof:id":101791297,
-    "wof:lastmodified":1566647345,
+    "wof:lastmodified":1582318741,
     "wof:name":"Nedeljanec",
     "wof:parent_id":85684835,
     "wof:placetype":"locality",

--- a/data/101/791/301/101791301.geojson
+++ b/data/101/791/301/101791301.geojson
@@ -113,6 +113,9 @@
         "wd:id":"Q610221"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8392c78b3e73a07a95ef8aeac115fe35",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647338,
+    "wof:lastmodified":1582318740,
     "wof:name":"Jal\u017eabet",
     "wof:parent_id":85684835,
     "wof:placetype":"locality",

--- a/data/101/791/309/101791309.geojson
+++ b/data/101/791/309/101791309.geojson
@@ -114,6 +114,9 @@
         "wk:page":"Ljube\u0161\u0107ica"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"264dea59dd3e0419c9b47b58b2748094",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":101791309,
-    "wof:lastmodified":1566647338,
+    "wof:lastmodified":1582318740,
     "wof:name":"Ljube\u0161\u0107ica",
     "wof:parent_id":85684835,
     "wof:placetype":"locality",

--- a/data/101/791/315/101791315.geojson
+++ b/data/101/791/315/101791315.geojson
@@ -97,6 +97,9 @@
         "wk:page":"Trnovec Bartolove\u010dki"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a04a5edbca459e858147906cfaba8815",
     "wof:hierarchy":[
         {
@@ -107,7 +110,7 @@
         }
     ],
     "wof:id":101791315,
-    "wof:lastmodified":1566647342,
+    "wof:lastmodified":1582318741,
     "wof:name":"Trnovec",
     "wof:parent_id":85684835,
     "wof:placetype":"locality",

--- a/data/101/791/317/101791317.geojson
+++ b/data/101/791/317/101791317.geojson
@@ -151,6 +151,9 @@
         "wd:id":"Q396474"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f6bbd37266f9aafaaf541ce44e20c71b",
     "wof:hierarchy":[
         {
@@ -164,7 +167,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647346,
+    "wof:lastmodified":1582318741,
     "wof:name":"Ludbreg",
     "wof:parent_id":85684835,
     "wof:placetype":"locality",

--- a/data/101/792/339/101792339.geojson
+++ b/data/101/792/339/101792339.geojson
@@ -141,6 +141,9 @@
         "wk:page":"Tu\u010depi"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"df9b0948cddc063bcdc9a5fdf7ba7ea3",
     "wof:hierarchy":[
         {
@@ -154,7 +157,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647408,
+    "wof:lastmodified":1582318751,
     "wof:name":"Tu\u010depi",
     "wof:parent_id":85684781,
     "wof:placetype":"locality",

--- a/data/101/792/341/101792341.geojson
+++ b/data/101/792/341/101792341.geojson
@@ -129,6 +129,9 @@
         "wk:page":"Brinje"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"136e0733b09dd90ec25164da4391bb68",
     "wof:hierarchy":[
         {
@@ -139,7 +142,7 @@
         }
     ],
     "wof:id":101792341,
-    "wof:lastmodified":1566647411,
+    "wof:lastmodified":1582318751,
     "wof:name":"Brinje",
     "wof:parent_id":85684737,
     "wof:placetype":"locality",

--- a/data/101/792/343/101792343.geojson
+++ b/data/101/792/343/101792343.geojson
@@ -171,6 +171,9 @@
         "wk:page":"Krk (town)"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f547ec761a9dacb84d3d9ca9e5aabf4e",
     "wof:hierarchy":[
         {
@@ -184,7 +187,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647416,
+    "wof:lastmodified":1582318752,
     "wof:name":"Krk",
     "wof:parent_id":85684789,
     "wof:placetype":"locality",

--- a/data/101/792/345/101792345.geojson
+++ b/data/101/792/345/101792345.geojson
@@ -100,6 +100,9 @@
         "qs_pg:id":1087875
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"55bef86e22549c6388aad318b42b4d64",
     "wof:hierarchy":[
         {
@@ -110,7 +113,7 @@
         }
     ],
     "wof:id":101792345,
-    "wof:lastmodified":1566647415,
+    "wof:lastmodified":1582318752,
     "wof:name":"Lu\u010dko",
     "wof:parent_id":85684811,
     "wof:placetype":"locality",

--- a/data/101/792/347/101792347.geojson
+++ b/data/101/792/347/101792347.geojson
@@ -87,6 +87,9 @@
         "wk:page":"Velika Mlaka"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a29c6cecc439af9885b1d4487ac6ad81",
     "wof:hierarchy":[
         {
@@ -97,7 +100,7 @@
         }
     ],
     "wof:id":101792347,
-    "wof:lastmodified":1566647411,
+    "wof:lastmodified":1582318751,
     "wof:name":"Velika Mlaka",
     "wof:parent_id":85684811,
     "wof:placetype":"locality",

--- a/data/101/792/351/101792351.geojson
+++ b/data/101/792/351/101792351.geojson
@@ -83,6 +83,9 @@
         "wk:page":"Je\u017edovec"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f8845f084d95c1c1c0fb94a2af4ea6d3",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
         }
     ],
     "wof:id":101792351,
-    "wof:lastmodified":1566647412,
+    "wof:lastmodified":1582318752,
     "wof:name":"Je\u017edovec",
     "wof:parent_id":85684811,
     "wof:placetype":"locality",

--- a/data/101/792/353/101792353.geojson
+++ b/data/101/792/353/101792353.geojson
@@ -95,6 +95,9 @@
         "wk:page":"Rezovac"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"39a7c37dbfd861560810023d962090c1",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
         }
     ],
     "wof:id":101792353,
-    "wof:lastmodified":1566647408,
+    "wof:lastmodified":1582318751,
     "wof:name":"Rezovac",
     "wof:parent_id":85684793,
     "wof:placetype":"locality",

--- a/data/101/792/357/101792357.geojson
+++ b/data/101/792/357/101792357.geojson
@@ -149,6 +149,9 @@
         "wd:id":"Q991263"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e384c6a6452f12c192f938fcd4a3f70b",
     "wof:hierarchy":[
         {
@@ -159,7 +162,7 @@
         }
     ],
     "wof:id":101792357,
-    "wof:lastmodified":1566647412,
+    "wof:lastmodified":1582318751,
     "wof:name":"Slatina",
     "wof:parent_id":85684793,
     "wof:placetype":"locality",

--- a/data/101/792/359/101792359.geojson
+++ b/data/101/792/359/101792359.geojson
@@ -107,6 +107,9 @@
         "wk:page":"\u010ca\u010dinci"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"abfc9d8c6d0608adc9ced3831ae681b8",
     "wof:hierarchy":[
         {
@@ -117,7 +120,7 @@
         }
     ],
     "wof:id":101792359,
-    "wof:lastmodified":1566647412,
+    "wof:lastmodified":1582318751,
     "wof:name":"\u010ca\u010dinci",
     "wof:parent_id":85684793,
     "wof:placetype":"locality",

--- a/data/101/792/361/101792361.geojson
+++ b/data/101/792/361/101792361.geojson
@@ -86,6 +86,9 @@
         "wk:page":"Pojatno"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8187038cc35a6d56c4eb8881a018b3c4",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
         }
     ],
     "wof:id":101792361,
-    "wof:lastmodified":1566647411,
+    "wof:lastmodified":1582318751,
     "wof:name":"Pojatno",
     "wof:parent_id":85684765,
     "wof:placetype":"locality",

--- a/data/101/792/365/101792365.geojson
+++ b/data/101/792/365/101792365.geojson
@@ -86,6 +86,9 @@
         "wk:page":"Jablanovec"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e3d50a114de9fd382003741e9050f820",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
         }
     ],
     "wof:id":101792365,
-    "wof:lastmodified":1566647408,
+    "wof:lastmodified":1582318751,
     "wof:name":"Jablanovec",
     "wof:parent_id":85684765,
     "wof:placetype":"locality",

--- a/data/101/792/371/101792371.geojson
+++ b/data/101/792/371/101792371.geojson
@@ -81,6 +81,9 @@
         "wk:page":"Gornji Stupnik"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5504046ddf34e26108ffdd79c4397a2c",
     "wof:hierarchy":[
         {
@@ -91,7 +94,7 @@
         }
     ],
     "wof:id":101792371,
-    "wof:lastmodified":1566647411,
+    "wof:lastmodified":1582318751,
     "wof:name":"Gornji Stupnik",
     "wof:parent_id":85684765,
     "wof:placetype":"locality",

--- a/data/101/792/387/101792387.geojson
+++ b/data/101/792/387/101792387.geojson
@@ -89,6 +89,9 @@
         "wk:page":"Mi\u010devec"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f957950663382d2c326ef341579e621d",
     "wof:hierarchy":[
         {
@@ -99,7 +102,7 @@
         }
     ],
     "wof:id":101792387,
-    "wof:lastmodified":1566647415,
+    "wof:lastmodified":1582318752,
     "wof:name":"Mi\u010devec",
     "wof:parent_id":85684765,
     "wof:placetype":"locality",

--- a/data/101/792/389/101792389.geojson
+++ b/data/101/792/389/101792389.geojson
@@ -84,6 +84,9 @@
         "qs_pg:id":1127266
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"80f5fb1c38b0178bdc835140be28e771",
     "wof:hierarchy":[
         {
@@ -94,7 +97,7 @@
         }
     ],
     "wof:id":101792389,
-    "wof:lastmodified":1566647415,
+    "wof:lastmodified":1582318752,
     "wof:name":"Rakov Potok",
     "wof:parent_id":85684765,
     "wof:placetype":"locality",

--- a/data/101/792/391/101792391.geojson
+++ b/data/101/792/391/101792391.geojson
@@ -166,6 +166,9 @@
         "wd:id":"Q390587"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d00a4f566493d235c71bcdf21ede5895",
     "wof:hierarchy":[
         {
@@ -179,7 +182,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647408,
+    "wof:lastmodified":1582318751,
     "wof:name":"Samobor",
     "wof:parent_id":85684765,
     "wof:placetype":"locality",

--- a/data/101/792/395/101792395.geojson
+++ b/data/101/792/395/101792395.geojson
@@ -157,6 +157,9 @@
         "wd:id":"Q754781"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"23635d6012b421ade73b2f4361bc12ad",
     "wof:hierarchy":[
         {
@@ -170,7 +173,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647412,
+    "wof:lastmodified":1582318751,
     "wof:name":"Vrbovec",
     "wof:parent_id":85684765,
     "wof:placetype":"locality",

--- a/data/101/792/401/101792401.geojson
+++ b/data/101/792/401/101792401.geojson
@@ -114,6 +114,9 @@
         "wk:page":"Brckovljani"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ea5c4bac90a6ae7e8c9b7eab2941cc2c",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647410,
+    "wof:lastmodified":1582318751,
     "wof:name":"Brckovljani",
     "wof:parent_id":85684765,
     "wof:placetype":"locality",

--- a/data/101/792/405/101792405.geojson
+++ b/data/101/792/405/101792405.geojson
@@ -112,6 +112,9 @@
         "wd:id":"Q387618"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ff775225d57e1e1005c2af5ea63cb99d",
     "wof:hierarchy":[
         {
@@ -122,7 +125,7 @@
         }
     ],
     "wof:id":101792405,
-    "wof:lastmodified":1566647414,
+    "wof:lastmodified":1582318752,
     "wof:name":"Lupoglav",
     "wof:parent_id":85684765,
     "wof:placetype":"locality",

--- a/data/101/792/407/101792407.geojson
+++ b/data/101/792/407/101792407.geojson
@@ -92,6 +92,9 @@
         "wk:page":"Ladimirevci"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1a114f0db16e6590e7625a1e2254c022",
     "wof:hierarchy":[
         {
@@ -102,7 +105,7 @@
         }
     ],
     "wof:id":101792407,
-    "wof:lastmodified":1566647411,
+    "wof:lastmodified":1582318751,
     "wof:name":"Ladimirevci",
     "wof:parent_id":85684805,
     "wof:placetype":"locality",

--- a/data/101/792/409/101792409.geojson
+++ b/data/101/792/409/101792409.geojson
@@ -161,6 +161,9 @@
         "wd:id":"Q830300"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"568e196187c6b498759114ac1682ddb3",
     "wof:hierarchy":[
         {
@@ -174,7 +177,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647410,
+    "wof:lastmodified":1582318751,
     "wof:name":"Valpovo",
     "wof:parent_id":85684805,
     "wof:placetype":"locality",

--- a/data/101/792/411/101792411.geojson
+++ b/data/101/792/411/101792411.geojson
@@ -105,6 +105,9 @@
         "wk:page":"Bizovac"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"50297eaddbc02775778e8cf95ab25fc1",
     "wof:hierarchy":[
         {
@@ -118,7 +121,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647413,
+    "wof:lastmodified":1582318752,
     "wof:name":"Bizovac",
     "wof:parent_id":85684805,
     "wof:placetype":"locality",

--- a/data/101/792/413/101792413.geojson
+++ b/data/101/792/413/101792413.geojson
@@ -108,6 +108,9 @@
         "wk:page":"Petrijevci"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0c9753cd3a543c29d3f0d580380dd3d1",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647409,
+    "wof:lastmodified":1582318751,
     "wof:name":"Petrijevci",
     "wof:parent_id":85684805,
     "wof:placetype":"locality",

--- a/data/101/792/415/101792415.geojson
+++ b/data/101/792/415/101792415.geojson
@@ -105,6 +105,9 @@
         "wk:page":"Kne\u017eevi Vinogradi"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"905d210957b263c39bd603b70d0a4f30",
     "wof:hierarchy":[
         {
@@ -118,7 +121,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647410,
+    "wof:lastmodified":1582318751,
     "wof:name":"Kne\u017eevi Vinogradi",
     "wof:parent_id":85684805,
     "wof:placetype":"locality",

--- a/data/101/792/417/101792417.geojson
+++ b/data/101/792/417/101792417.geojson
@@ -108,6 +108,9 @@
         "wk:page":"\u010ceminac"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3c684a632cc42c63f0fac5c425380611",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647413,
+    "wof:lastmodified":1582318752,
     "wof:name":"\u010ceminac",
     "wof:parent_id":85684805,
     "wof:placetype":"locality",

--- a/data/101/792/419/101792419.geojson
+++ b/data/101/792/419/101792419.geojson
@@ -89,6 +89,9 @@
         "wk:page":"Karanac"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a6b522da057117791d58926e8aefaff8",
     "wof:hierarchy":[
         {
@@ -99,7 +102,7 @@
         }
     ],
     "wof:id":101792419,
-    "wof:lastmodified":1566647413,
+    "wof:lastmodified":1582318752,
     "wof:name":"Karanac",
     "wof:parent_id":85684805,
     "wof:placetype":"locality",

--- a/data/101/792/423/101792423.geojson
+++ b/data/101/792/423/101792423.geojson
@@ -123,6 +123,9 @@
         "wk:page":"Bilje"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f937283efbc910fc532be3a530112f8a",
     "wof:hierarchy":[
         {
@@ -136,7 +139,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647410,
+    "wof:lastmodified":1582318751,
     "wof:name":"Bilje",
     "wof:parent_id":85684805,
     "wof:placetype":"locality",

--- a/data/101/792/425/101792425.geojson
+++ b/data/101/792/425/101792425.geojson
@@ -120,6 +120,9 @@
         "wk:page":"Darda, Croatia"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7b9118f17f5cdf1a10a13e329ef02403",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647409,
+    "wof:lastmodified":1582318751,
     "wof:name":"Darda",
     "wof:parent_id":85684805,
     "wof:placetype":"locality",

--- a/data/101/792/427/101792427.geojson
+++ b/data/101/792/427/101792427.geojson
@@ -272,6 +272,9 @@
         "wk:page":"Sarva\u0161"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"87c5a8509af8a6f089cdee36b1313a72",
     "wof:hierarchy":[
         {
@@ -282,7 +285,7 @@
         }
     ],
     "wof:id":101792427,
-    "wof:lastmodified":1566647413,
+    "wof:lastmodified":1582318752,
     "wof:name":"Sarva\u0161",
     "wof:parent_id":85684805,
     "wof:placetype":"locality",

--- a/data/101/792/429/101792429.geojson
+++ b/data/101/792/429/101792429.geojson
@@ -88,6 +88,9 @@
         "wd:id":"Q794862"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8a11ac85ec5174ec1df8c7c8b4b85223",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
         }
     ],
     "wof:id":101792429,
-    "wof:lastmodified":1566647413,
+    "wof:lastmodified":1582318752,
     "wof:name":"Bijelo Brdo",
     "wof:parent_id":85684805,
     "wof:placetype":"locality",

--- a/data/101/792/431/101792431.geojson
+++ b/data/101/792/431/101792431.geojson
@@ -104,6 +104,9 @@
         "wk:page":"Ko\u0161ka"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"03011c2baf5debd83cb8288afe9db7bb",
     "wof:hierarchy":[
         {
@@ -114,7 +117,7 @@
         }
     ],
     "wof:id":101792431,
-    "wof:lastmodified":1566647410,
+    "wof:lastmodified":1582318751,
     "wof:name":"Ko\u0161ka",
     "wof:parent_id":85684805,
     "wof:placetype":"locality",

--- a/data/101/792/433/101792433.geojson
+++ b/data/101/792/433/101792433.geojson
@@ -109,6 +109,9 @@
         "wk:page":"Viljevo"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d21949f71f76ee6bbef7fbb207c5452f",
     "wof:hierarchy":[
         {
@@ -122,7 +125,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647415,
+    "wof:lastmodified":1582318752,
     "wof:name":"Viljevo",
     "wof:parent_id":85684805,
     "wof:placetype":"locality",

--- a/data/101/792/435/101792435.geojson
+++ b/data/101/792/435/101792435.geojson
@@ -154,6 +154,9 @@
         "wk:page":"Donji Miholjac"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8d494a6265db4f9690bfc8c7646657a1",
     "wof:hierarchy":[
         {
@@ -167,7 +170,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647415,
+    "wof:lastmodified":1582318752,
     "wof:name":"Donji Miholjac",
     "wof:parent_id":85684805,
     "wof:placetype":"locality",

--- a/data/101/792/441/101792441.geojson
+++ b/data/101/792/441/101792441.geojson
@@ -108,6 +108,9 @@
         "wk:page":"Rovi\u0161\u0107e"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"04e9f150834e3d91bca66f0326e7b2a7",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647409,
+    "wof:lastmodified":1582318751,
     "wof:name":"Rovi\u0161\u0107e",
     "wof:parent_id":85684753,
     "wof:placetype":"locality",

--- a/data/101/792/447/101792447.geojson
+++ b/data/101/792/447/101792447.geojson
@@ -114,6 +114,9 @@
         "wk:page":"Hercegovac, Croatia"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b3dda1c8e0235f4c9dce74bf994900db",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647409,
+    "wof:lastmodified":1582318751,
     "wof:name":"Hercegovac",
     "wof:parent_id":85684753,
     "wof:placetype":"locality",

--- a/data/101/793/481/101793481.geojson
+++ b/data/101/793/481/101793481.geojson
@@ -118,6 +118,9 @@
         "wk:page":"Kaptol, Po\u017eega-Slavonia County"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5e427a0d88d77e4d9c372ef794837eae",
     "wof:hierarchy":[
         {
@@ -131,7 +134,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647385,
+    "wof:lastmodified":1582318747,
     "wof:name":"Kaptol",
     "wof:parent_id":85684763,
     "wof:placetype":"locality",

--- a/data/101/793/485/101793485.geojson
+++ b/data/101/793/485/101793485.geojson
@@ -110,6 +110,9 @@
         "wk:page":"Nu\u0161tar"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"024431d893f5e6a0c87ce1e79b0d8ae6",
     "wof:hierarchy":[
         {
@@ -120,7 +123,7 @@
         }
     ],
     "wof:id":101793485,
-    "wof:lastmodified":1566647380,
+    "wof:lastmodified":1582318746,
     "wof:name":"Nu\u0161tar",
     "wof:parent_id":85684733,
     "wof:placetype":"locality",

--- a/data/101/793/487/101793487.geojson
+++ b/data/101/793/487/101793487.geojson
@@ -96,6 +96,9 @@
         "wk:page":"Ceri\u0107"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6837c5df699a00269710ff2dff2f4648",
     "wof:hierarchy":[
         {
@@ -106,7 +109,7 @@
         }
     ],
     "wof:id":101793487,
-    "wof:lastmodified":1566647385,
+    "wof:lastmodified":1582318747,
     "wof:name":"Ceri\u0107",
     "wof:parent_id":85684733,
     "wof:placetype":"locality",

--- a/data/101/793/489/101793489.geojson
+++ b/data/101/793/489/101793489.geojson
@@ -94,6 +94,9 @@
         "wk:page":"Br\u0161adin"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"233b2664dab587ab14ee844a1338d70c",
     "wof:hierarchy":[
         {
@@ -104,7 +107,7 @@
         }
     ],
     "wof:id":101793489,
-    "wof:lastmodified":1566647385,
+    "wof:lastmodified":1582318747,
     "wof:name":"Br\u0161adin",
     "wof:parent_id":85684733,
     "wof:placetype":"locality",

--- a/data/101/793/491/101793491.geojson
+++ b/data/101/793/491/101793491.geojson
@@ -192,6 +192,9 @@
         "wk:page":"Trpinja"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d3095e7611460baa8cef5ba55e985253",
     "wof:hierarchy":[
         {
@@ -205,7 +208,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647381,
+    "wof:lastmodified":1582318746,
     "wof:name":"Trpinja",
     "wof:parent_id":85684733,
     "wof:placetype":"locality",

--- a/data/101/793/493/101793493.geojson
+++ b/data/101/793/493/101793493.geojson
@@ -117,6 +117,9 @@
         "wk:page":"Negoslavci"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ae07a06a9190202d38ec5538249295fc",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647385,
+    "wof:lastmodified":1582318747,
     "wof:name":"Negoslavci",
     "wof:parent_id":85684733,
     "wof:placetype":"locality",

--- a/data/101/793/495/101793495.geojson
+++ b/data/101/793/495/101793495.geojson
@@ -117,6 +117,9 @@
         "wk:page":"Tovarnik"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ca4d15648215e7b3fc516af54885115f",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647385,
+    "wof:lastmodified":1582318747,
     "wof:name":"Tovarnik",
     "wof:parent_id":85684733,
     "wof:placetype":"locality",

--- a/data/101/793/497/101793497.geojson
+++ b/data/101/793/497/101793497.geojson
@@ -83,6 +83,9 @@
         "wk:page":"Ila\u010da"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8da04e085bfcc24635821d94ab996b6b",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
         }
     ],
     "wof:id":101793497,
-    "wof:lastmodified":1566647381,
+    "wof:lastmodified":1582318746,
     "wof:name":"Ila\u010da",
     "wof:parent_id":85684733,
     "wof:placetype":"locality",

--- a/data/101/793/499/101793499.geojson
+++ b/data/101/793/499/101793499.geojson
@@ -108,6 +108,9 @@
         "wk:page":"Privlaka, Vukovar-Srijem County"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"471c438876f9b85df63887745dc3a9b6",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647381,
+    "wof:lastmodified":1582318746,
     "wof:name":"Privlaka",
     "wof:parent_id":85684733,
     "wof:placetype":"locality",

--- a/data/101/793/503/101793503.geojson
+++ b/data/101/793/503/101793503.geojson
@@ -83,6 +83,9 @@
         "wk:page":"Slakovci"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"bd6d6879fa80171b67abea631574fb30",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
         }
     ],
     "wof:id":101793503,
-    "wof:lastmodified":1566647379,
+    "wof:lastmodified":1582318746,
     "wof:name":"Slakovci",
     "wof:parent_id":85684733,
     "wof:placetype":"locality",

--- a/data/101/793/505/101793505.geojson
+++ b/data/101/793/505/101793505.geojson
@@ -120,6 +120,9 @@
         "wk:page":"Cerna, Croatia"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5236e68c9b260919d9b3d47feab4b38f",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647379,
+    "wof:lastmodified":1582318746,
     "wof:name":"Cerna",
     "wof:parent_id":85684733,
     "wof:placetype":"locality",

--- a/data/101/793/507/101793507.geojson
+++ b/data/101/793/507/101793507.geojson
@@ -83,6 +83,9 @@
         "wk:page":"Retkovci"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f57a1b5b367cfc069d24f44e4dcec79f",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
         }
     ],
     "wof:id":101793507,
-    "wof:lastmodified":1566647384,
+    "wof:lastmodified":1582318747,
     "wof:name":"Retkovci",
     "wof:parent_id":85684733,
     "wof:placetype":"locality",

--- a/data/101/793/509/101793509.geojson
+++ b/data/101/793/509/101793509.geojson
@@ -108,6 +108,9 @@
         "wk:page":"Jarmina"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"259f2751cd7d569dbc820aafd9fb4dcc",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647384,
+    "wof:lastmodified":1582318747,
     "wof:name":"Jarmina",
     "wof:parent_id":85684733,
     "wof:placetype":"locality",

--- a/data/101/793/513/101793513.geojson
+++ b/data/101/793/513/101793513.geojson
@@ -111,6 +111,9 @@
         "wk:page":"Ivankovo, Croatia"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"434c742d853ff594cedf581893bacb10",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647386,
+    "wof:lastmodified":1582318747,
     "wof:name":"Ivankovo",
     "wof:parent_id":85684733,
     "wof:placetype":"locality",

--- a/data/101/793/515/101793515.geojson
+++ b/data/101/793/515/101793515.geojson
@@ -98,6 +98,9 @@
         "wk:page":"Bobota, Croatia"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f79e38ff164b64e54e52488f721cc7a8",
     "wof:hierarchy":[
         {
@@ -108,7 +111,7 @@
         }
     ],
     "wof:id":101793515,
-    "wof:lastmodified":1566647387,
+    "wof:lastmodified":1582318747,
     "wof:name":"Bobota",
     "wof:parent_id":85684733,
     "wof:placetype":"locality",

--- a/data/101/793/517/101793517.geojson
+++ b/data/101/793/517/101793517.geojson
@@ -95,6 +95,9 @@
         "wk:page":"Bapska"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"05ac6afde0e7eaa0875a75b2fc8c52b7",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
         }
     ],
     "wof:id":101793517,
-    "wof:lastmodified":1566647381,
+    "wof:lastmodified":1582318746,
     "wof:name":"Bapska",
     "wof:parent_id":85684733,
     "wof:placetype":"locality",

--- a/data/101/793/521/101793521.geojson
+++ b/data/101/793/521/101793521.geojson
@@ -177,6 +177,9 @@
         "wk:page":"Ilok"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"50e34688f2927b5ecd752dbc88401003",
     "wof:hierarchy":[
         {
@@ -190,7 +193,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647381,
+    "wof:lastmodified":1582318746,
     "wof:name":"Ilok",
     "wof:parent_id":85684733,
     "wof:placetype":"locality",

--- a/data/101/793/525/101793525.geojson
+++ b/data/101/793/525/101793525.geojson
@@ -149,6 +149,9 @@
         "wd:id":"Q396512"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"fca82eda4a2bdbbca6a61a406c9e4436",
     "wof:hierarchy":[
         {
@@ -162,7 +165,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647386,
+    "wof:lastmodified":1582318747,
     "wof:name":"Petrinja",
     "wof:parent_id":85684769,
     "wof:placetype":"locality",

--- a/data/101/793/527/101793527.geojson
+++ b/data/101/793/527/101793527.geojson
@@ -153,6 +153,9 @@
         "wd:id":"Q397639"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"80bc3519e2f22ee8320ce4416c3a4924",
     "wof:hierarchy":[
         {
@@ -166,7 +169,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647382,
+    "wof:lastmodified":1582318746,
     "wof:name":"Novska",
     "wof:parent_id":85684769,
     "wof:placetype":"locality",

--- a/data/101/793/529/101793529.geojson
+++ b/data/101/793/529/101793529.geojson
@@ -123,6 +123,9 @@
         "wk:page":"Lipovljani"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"63968763367403ced16e9389f50ab2e4",
     "wof:hierarchy":[
         {
@@ -136,7 +139,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647382,
+    "wof:lastmodified":1582318747,
     "wof:name":"Lipovljani",
     "wof:parent_id":85684769,
     "wof:placetype":"locality",

--- a/data/101/793/531/101793531.geojson
+++ b/data/101/793/531/101793531.geojson
@@ -95,6 +95,9 @@
         "wk:page":"Osekovo"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"fb79794267fd86243bd77e504a036f68",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
         }
     ],
     "wof:id":101793531,
-    "wof:lastmodified":1566647384,
+    "wof:lastmodified":1582318747,
     "wof:name":"Osekovo",
     "wof:parent_id":85684769,
     "wof:placetype":"locality",

--- a/data/101/793/533/101793533.geojson
+++ b/data/101/793/533/101793533.geojson
@@ -116,6 +116,9 @@
         "qs_pg:id":1083092
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a3782521ac83f53e35a04bcc6329b7cd",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647379,
+    "wof:lastmodified":1582318746,
     "wof:name":"Sunja",
     "wof:parent_id":85684769,
     "wof:placetype":"locality",

--- a/data/101/793/535/101793535.geojson
+++ b/data/101/793/535/101793535.geojson
@@ -127,6 +127,9 @@
         "qs_pg:id":1156920
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"fbd5edd95d30fd7ca8ce8e2c399307f7",
     "wof:hierarchy":[
         {
@@ -140,7 +143,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647380,
+    "wof:lastmodified":1582318746,
     "wof:name":"Popova\u010da",
     "wof:parent_id":85684769,
     "wof:placetype":"locality",

--- a/data/101/793/539/101793539.geojson
+++ b/data/101/793/539/101793539.geojson
@@ -147,6 +147,9 @@
         "wk:page":"Duga Resa"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"65723f37cd5cbb31cf806289e11739d0",
     "wof:hierarchy":[
         {
@@ -160,7 +163,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647383,
+    "wof:lastmodified":1582318747,
     "wof:name":"Duga Resa",
     "wof:parent_id":85684819,
     "wof:placetype":"locality",

--- a/data/101/793/541/101793541.geojson
+++ b/data/101/793/541/101793541.geojson
@@ -330,7 +330,8 @@
     "qs:type":"rural point-in-poly",
     "src:geom":"quattroshapes",
     "src:geom_alt":[
-        "quattroshapes_pg"
+        "quattroshapes_pg",
+        "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
     "wd:wordcount":1915,
@@ -351,6 +352,10 @@
         "qs_pg:id":528878
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "naturalearth"
+    ],
     "wof:geomhash":"8b2a8b28de0d9aa42ea25148b73761f3",
     "wof:hierarchy":[
         {
@@ -361,7 +366,7 @@
         }
     ],
     "wof:id":101793541,
-    "wof:lastmodified":1566647386,
+    "wof:lastmodified":1582318747,
     "wof:name":"Karlovac",
     "wof:parent_id":85684819,
     "wof:placetype":"locality",

--- a/data/101/793/543/101793543.geojson
+++ b/data/101/793/543/101793543.geojson
@@ -148,6 +148,9 @@
         "wd:id":"Q396518"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2c283f58ad33973911eef169292b995e",
     "wof:hierarchy":[
         {
@@ -161,7 +164,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647382,
+    "wof:lastmodified":1582318746,
     "wof:name":"Ozalj",
     "wof:parent_id":85684819,
     "wof:placetype":"locality",

--- a/data/101/793/547/101793547.geojson
+++ b/data/101/793/547/101793547.geojson
@@ -163,6 +163,9 @@
         "wd:id":"Q397692"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1b4b3a5743ba07661753a630ac56ed07",
     "wof:hierarchy":[
         {
@@ -173,7 +176,7 @@
         }
     ],
     "wof:id":101793547,
-    "wof:lastmodified":1566647386,
+    "wof:lastmodified":1582318747,
     "wof:name":"Orahovica",
     "wof:parent_id":85684793,
     "wof:placetype":"locality",

--- a/data/101/793/549/101793549.geojson
+++ b/data/101/793/549/101793549.geojson
@@ -153,6 +153,9 @@
         "wk:page":"Jastrebarsko"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8abfacc5f666c1e4dd22817e53933d90",
     "wof:hierarchy":[
         {
@@ -166,7 +169,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647386,
+    "wof:lastmodified":1582318747,
     "wof:name":"Jastrebarsko",
     "wof:parent_id":85684765,
     "wof:placetype":"locality",

--- a/data/101/793/557/101793557.geojson
+++ b/data/101/793/557/101793557.geojson
@@ -113,6 +113,9 @@
         "wk:page":"Turopolje"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"02ff34f2942c1ef25f89af7a693f4b99",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
         }
     ],
     "wof:id":101793557,
-    "wof:lastmodified":1566647379,
+    "wof:lastmodified":1582318746,
     "wof:name":"Turopolje",
     "wof:parent_id":85684765,
     "wof:placetype":"locality",

--- a/data/101/793/559/101793559.geojson
+++ b/data/101/793/559/101793559.geojson
@@ -86,6 +86,9 @@
         "wk:page":"Mraclin"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d91aeace09a85ce40fb8f649973a39ec",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
         }
     ],
     "wof:id":101793559,
-    "wof:lastmodified":1566647379,
+    "wof:lastmodified":1582318746,
     "wof:name":"Mraclin",
     "wof:parent_id":85684765,
     "wof:placetype":"locality",

--- a/data/101/793/561/101793561.geojson
+++ b/data/101/793/561/101793561.geojson
@@ -95,6 +95,9 @@
         "wk:page":"Tenja"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b50aa8f131cc8bf485abb860d4e0a8b5",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
         }
     ],
     "wof:id":101793561,
-    "wof:lastmodified":1566647379,
+    "wof:lastmodified":1582318746,
     "wof:name":"Tenja",
     "wof:parent_id":85684805,
     "wof:placetype":"locality",

--- a/data/101/793/563/101793563.geojson
+++ b/data/101/793/563/101793563.geojson
@@ -108,6 +108,9 @@
         "wk:page":"Antunovac"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d5c9fd355f1a7f1a4de4f5671f6e5116",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647383,
+    "wof:lastmodified":1582318747,
     "wof:name":"Antunovac",
     "wof:parent_id":85684805,
     "wof:placetype":"locality",

--- a/data/101/793/565/101793565.geojson
+++ b/data/101/793/565/101793565.geojson
@@ -115,6 +115,9 @@
         "wk:page":"Vrpolje"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"50622b5f77dcf767044dcf8bfa961447",
     "wof:hierarchy":[
         {
@@ -128,7 +131,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647384,
+    "wof:lastmodified":1582318747,
     "wof:name":"Vrpolje",
     "wof:parent_id":85684749,
     "wof:placetype":"locality",

--- a/data/101/793/567/101793567.geojson
+++ b/data/101/793/567/101793567.geojson
@@ -108,6 +108,9 @@
         "wk:page":"Feri\u010danci"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7eaa3f692660488a3f5529e0b413df32",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647378,
+    "wof:lastmodified":1582318746,
     "wof:name":"Feri\u010danci",
     "wof:parent_id":85684805,
     "wof:placetype":"locality",

--- a/data/101/793/575/101793575.geojson
+++ b/data/101/793/575/101793575.geojson
@@ -50,6 +50,9 @@
         "qs_pg:id":1275689
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"67ca4631e67971e8e0cc1972f289fcd1",
     "wof:hierarchy":[
         {
@@ -60,7 +63,7 @@
         }
     ],
     "wof:id":101793575,
-    "wof:lastmodified":1566647382,
+    "wof:lastmodified":1582318746,
     "wof:name":"Velimirovac",
     "wof:parent_id":85684805,
     "wof:placetype":"locality",

--- a/data/101/793/577/101793577.geojson
+++ b/data/101/793/577/101793577.geojson
@@ -92,6 +92,9 @@
         "wk:page":"Jelisavac"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"60bcaed87bc73d6e6e38b33ec33b2d35",
     "wof:hierarchy":[
         {
@@ -102,7 +105,7 @@
         }
     ],
     "wof:id":101793577,
-    "wof:lastmodified":1566647387,
+    "wof:lastmodified":1582318747,
     "wof:name":"Jelisavac",
     "wof:parent_id":85684805,
     "wof:placetype":"locality",

--- a/data/101/793/579/101793579.geojson
+++ b/data/101/793/579/101793579.geojson
@@ -114,6 +114,9 @@
         "wk:page":"Vladislavci"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7675454b0b7fa3572085874fe182b610",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647387,
+    "wof:lastmodified":1582318747,
     "wof:name":"Vladislavci",
     "wof:parent_id":85684805,
     "wof:placetype":"locality",

--- a/data/101/793/581/101793581.geojson
+++ b/data/101/793/581/101793581.geojson
@@ -108,6 +108,9 @@
         "wk:page":"Gorjani"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"51f92671b0bcc9467759630f5127fdf2",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647382,
+    "wof:lastmodified":1582318746,
     "wof:name":"Gorjani",
     "wof:parent_id":85684805,
     "wof:placetype":"locality",

--- a/data/101/793/587/101793587.geojson
+++ b/data/101/793/587/101793587.geojson
@@ -101,6 +101,9 @@
         "wk:page":"Vi\u0161kovci"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e1f29688f1d5ad5bf0cda4e9c8970395",
     "wof:hierarchy":[
         {
@@ -111,7 +114,7 @@
         }
     ],
     "wof:id":101793587,
-    "wof:lastmodified":1566647383,
+    "wof:lastmodified":1582318747,
     "wof:name":"Vi\u0161kovci",
     "wof:parent_id":85684805,
     "wof:placetype":"locality",

--- a/data/101/793/589/101793589.geojson
+++ b/data/101/793/589/101793589.geojson
@@ -105,6 +105,9 @@
         "wk:page":"Semeljci"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"298b281d43d7f74d2462d4c39bda187f",
     "wof:hierarchy":[
         {
@@ -118,7 +121,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647383,
+    "wof:lastmodified":1582318747,
     "wof:name":"Semeljci",
     "wof:parent_id":85684805,
     "wof:placetype":"locality",

--- a/data/101/793/593/101793593.geojson
+++ b/data/101/793/593/101793593.geojson
@@ -194,6 +194,9 @@
         "wk:page":"\u0110akovo"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6350073cc0f32e7207f980892be4beb6",
     "wof:hierarchy":[
         {
@@ -207,7 +210,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647378,
+    "wof:lastmodified":1582318746,
     "wof:name":"\u0110akovo",
     "wof:parent_id":85684805,
     "wof:placetype":"locality",

--- a/data/101/793/599/101793599.geojson
+++ b/data/101/793/599/101793599.geojson
@@ -111,6 +111,9 @@
         "wk:page":"Ernestinovo"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"668244a0c7a7414948f2db9db2324148",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647383,
+    "wof:lastmodified":1582318747,
     "wof:name":"Ernestinovo",
     "wof:parent_id":85684805,
     "wof:placetype":"locality",

--- a/data/101/793/601/101793601.geojson
+++ b/data/101/793/601/101793601.geojson
@@ -98,6 +98,9 @@
         "wk:page":"Laslovo"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"993d521fb1394dd4bb80f4cf4501a75f",
     "wof:hierarchy":[
         {
@@ -108,7 +111,7 @@
         }
     ],
     "wof:id":101793601,
-    "wof:lastmodified":1566647385,
+    "wof:lastmodified":1582318747,
     "wof:name":"Laslovo",
     "wof:parent_id":85684805,
     "wof:placetype":"locality",

--- a/data/101/793/611/101793611.geojson
+++ b/data/101/793/611/101793611.geojson
@@ -125,6 +125,9 @@
         "wk:page":"Dalj"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"85a6e4e508686317f8e4ad5a6c27e603",
     "wof:hierarchy":[
         {
@@ -135,7 +138,7 @@
         }
     ],
     "wof:id":101793611,
-    "wof:lastmodified":1566647380,
+    "wof:lastmodified":1582318746,
     "wof:name":"Dalj",
     "wof:parent_id":85684805,
     "wof:placetype":"locality",

--- a/data/101/793/613/101793613.geojson
+++ b/data/101/793/613/101793613.geojson
@@ -167,6 +167,9 @@
         "wk:page":"Daruvar"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"dc3af3cfeacb05d982e3a6f50eb9f488",
     "wof:hierarchy":[
         {
@@ -180,7 +183,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647384,
+    "wof:lastmodified":1582318747,
     "wof:name":"Daruvar",
     "wof:parent_id":85684753,
     "wof:placetype":"locality",

--- a/data/101/793/615/101793615.geojson
+++ b/data/101/793/615/101793615.geojson
@@ -111,6 +111,9 @@
         "wk:page":"Sira\u010d"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4cb718b54441674f867de3c40a427b05",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647385,
+    "wof:lastmodified":1582318747,
     "wof:name":"Sira\u010d",
     "wof:parent_id":85684753,
     "wof:placetype":"locality",

--- a/data/101/794/603/101794603.geojson
+++ b/data/101/794/603/101794603.geojson
@@ -101,6 +101,9 @@
         "wk:page":"Njivice, Croatia"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1c5affb97a809edaa716980a7e2c85f0",
     "wof:hierarchy":[
         {
@@ -111,7 +114,7 @@
         }
     ],
     "wof:id":101794603,
-    "wof:lastmodified":1566647393,
+    "wof:lastmodified":1582318748,
     "wof:name":"Njivice",
     "wof:parent_id":85684789,
     "wof:placetype":"locality",

--- a/data/101/794/607/101794607.geojson
+++ b/data/101/794/607/101794607.geojson
@@ -113,6 +113,9 @@
         "wk:page":"Ra\u0161a, Istria County"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b45e7e4825426ae5c72e3f5021c3f8b3",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
         }
     ],
     "wof:id":101794607,
-    "wof:lastmodified":1566647398,
+    "wof:lastmodified":1582318749,
     "wof:name":"Ra\u0161a",
     "wof:parent_id":85684829,
     "wof:placetype":"locality",

--- a/data/101/794/609/101794609.geojson
+++ b/data/101/794/609/101794609.geojson
@@ -116,6 +116,9 @@
         "wk:page":"Rabac"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"771d39221f702651dbe914597c7e124b",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":101794609,
-    "wof:lastmodified":1566647398,
+    "wof:lastmodified":1582318749,
     "wof:name":"Rabac",
     "wof:parent_id":85684829,
     "wof:placetype":"locality",

--- a/data/101/794/613/101794613.geojson
+++ b/data/101/794/613/101794613.geojson
@@ -181,6 +181,9 @@
         "wk:page":"Novigrad, Istria County"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3087455e6cbe2a2711f33c238097fbd8",
     "wof:hierarchy":[
         {
@@ -194,7 +197,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647395,
+    "wof:lastmodified":1582318748,
     "wof:name":"Novigrad",
     "wof:parent_id":85684829,
     "wof:placetype":"locality",

--- a/data/101/794/619/101794619.geojson
+++ b/data/101/794/619/101794619.geojson
@@ -174,6 +174,9 @@
         "wk:page":"Buje"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"499bbbab86005a78f11044fee28a2535",
     "wof:hierarchy":[
         {
@@ -187,7 +190,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647391,
+    "wof:lastmodified":1582318748,
     "wof:name":"Buje",
     "wof:parent_id":85684829,
     "wof:placetype":"locality",

--- a/data/101/794/621/101794621.geojson
+++ b/data/101/794/621/101794621.geojson
@@ -329,6 +329,9 @@
         "wk:page":"Umag"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4fd5216f36c0241d24cfbe8e84158abd",
     "wof:hierarchy":[
         {
@@ -342,7 +345,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647391,
+    "wof:lastmodified":1582318748,
     "wof:name":"Umag",
     "wof:parent_id":85684829,
     "wof:placetype":"locality",

--- a/data/101/794/623/101794623.geojson
+++ b/data/101/794/623/101794623.geojson
@@ -158,6 +158,9 @@
         "wk:page":"Buzet"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"26fbe15c1d4abfae328d4271262edb04",
     "wof:hierarchy":[
         {
@@ -171,7 +174,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647396,
+    "wof:lastmodified":1582318749,
     "wof:name":"Buzet",
     "wof:parent_id":85684829,
     "wof:placetype":"locality",

--- a/data/101/794/625/101794625.geojson
+++ b/data/101/794/625/101794625.geojson
@@ -218,6 +218,9 @@
         "wk:page":"Pore\u010d"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c42d0a6e18800059556812f35c65e511",
     "wof:hierarchy":[
         {
@@ -231,7 +234,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647395,
+    "wof:lastmodified":1582318749,
     "wof:name":"Pore\u010d",
     "wof:parent_id":85684829,
     "wof:placetype":"locality",

--- a/data/101/794/627/101794627.geojson
+++ b/data/101/794/627/101794627.geojson
@@ -206,6 +206,9 @@
         "wk:page":"Pazin"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1737ef5e4efc883bd888f792425e43f3",
     "wof:hierarchy":[
         {
@@ -219,7 +222,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647392,
+    "wof:lastmodified":1582318748,
     "wof:name":"Pazin",
     "wof:parent_id":85684829,
     "wof:placetype":"locality",

--- a/data/101/794/629/101794629.geojson
+++ b/data/101/794/629/101794629.geojson
@@ -108,6 +108,9 @@
         "wk:page":"Sikirevci"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6995b0dc97f17c1005ea3f570cfe5fa1",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647392,
+    "wof:lastmodified":1582318748,
     "wof:name":"Sikirevci",
     "wof:parent_id":85684749,
     "wof:placetype":"locality",

--- a/data/101/794/631/101794631.geojson
+++ b/data/101/794/631/101794631.geojson
@@ -100,6 +100,9 @@
         "wk:page":"Velika Kopanica"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"09f01805bd56cddd8cf3da4ca1b4b0fe",
     "wof:hierarchy":[
         {
@@ -113,7 +116,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647398,
+    "wof:lastmodified":1582318749,
     "wof:name":"Velika Kopanica",
     "wof:parent_id":85684749,
     "wof:placetype":"locality",

--- a/data/101/794/633/101794633.geojson
+++ b/data/101/794/633/101794633.geojson
@@ -105,6 +105,9 @@
         "wk:page":"Gundinci"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"548bffadce516da88719b4b29a7cd44e",
     "wof:hierarchy":[
         {
@@ -118,7 +121,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647392,
+    "wof:lastmodified":1582318748,
     "wof:name":"Gundinci",
     "wof:parent_id":85684749,
     "wof:placetype":"locality",

--- a/data/101/794/637/101794637.geojson
+++ b/data/101/794/637/101794637.geojson
@@ -108,6 +108,9 @@
         "wk:page":"Gar\u010din"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2dd4e3087421096be497697e2ac8ed05",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647397,
+    "wof:lastmodified":1582318749,
     "wof:name":"Gar\u010din",
     "wof:parent_id":85684749,
     "wof:placetype":"locality",

--- a/data/101/794/639/101794639.geojson
+++ b/data/101/794/639/101794639.geojson
@@ -105,6 +105,9 @@
         "wk:page":"Donji Andrijevci"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a3e25309f5988ac549a2bd87d5b2b86e",
     "wof:hierarchy":[
         {
@@ -118,7 +121,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647398,
+    "wof:lastmodified":1582318749,
     "wof:name":"Donji Andrijevci",
     "wof:parent_id":85684749,
     "wof:placetype":"locality",

--- a/data/101/794/641/101794641.geojson
+++ b/data/101/794/641/101794641.geojson
@@ -108,6 +108,9 @@
         "wk:page":"Bukovlje"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"bddfff8e26279170892daa5403746518",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647396,
+    "wof:lastmodified":1582318749,
     "wof:name":"Bukovlje",
     "wof:parent_id":85684749,
     "wof:placetype":"locality",

--- a/data/101/794/651/101794651.geojson
+++ b/data/101/794/651/101794651.geojson
@@ -123,6 +123,9 @@
         "wk:page":"Oku\u010dani"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5c19bbdbefd9594160d756594a6accc8",
     "wof:hierarchy":[
         {
@@ -136,7 +139,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647392,
+    "wof:lastmodified":1582318748,
     "wof:name":"Oku\u010dani",
     "wof:parent_id":85684749,
     "wof:placetype":"locality",

--- a/data/101/794/655/101794655.geojson
+++ b/data/101/794/655/101794655.geojson
@@ -91,6 +91,9 @@
         "wd:id":"Q343156"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"21a58e5e33c0c81e287220e4d6eead9a",
     "wof:hierarchy":[
         {
@@ -101,7 +104,7 @@
         }
     ],
     "wof:id":101794655,
-    "wof:lastmodified":1566647397,
+    "wof:lastmodified":1582318749,
     "wof:name":"Bribir",
     "wof:parent_id":85684789,
     "wof:placetype":"locality",

--- a/data/101/794/657/101794657.geojson
+++ b/data/101/794/657/101794657.geojson
@@ -157,6 +157,9 @@
         "wk:page":"Novi Vinodolski"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c067bd3b9ef965381380c5dc225baed8",
     "wof:hierarchy":[
         {
@@ -170,7 +173,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647394,
+    "wof:lastmodified":1582318748,
     "wof:name":"Novi Vinodolski",
     "wof:parent_id":85684789,
     "wof:placetype":"locality",

--- a/data/101/794/659/101794659.geojson
+++ b/data/101/794/659/101794659.geojson
@@ -92,6 +92,9 @@
         "wk:page":"Krasica"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4f10617b380bc6ce81c896253d88205d",
     "wof:hierarchy":[
         {
@@ -102,7 +105,7 @@
         }
     ],
     "wof:id":101794659,
-    "wof:lastmodified":1566647393,
+    "wof:lastmodified":1582318748,
     "wof:name":"Krasica",
     "wof:parent_id":85684789,
     "wof:placetype":"locality",

--- a/data/101/794/661/101794661.geojson
+++ b/data/101/794/661/101794661.geojson
@@ -144,6 +144,9 @@
         "wk:page":"Kraljevica"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"fc6cf91a81cd5003d55ee50effd710f2",
     "wof:hierarchy":[
         {
@@ -157,7 +160,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647393,
+    "wof:lastmodified":1582318748,
     "wof:name":"Kraljevica",
     "wof:parent_id":85684789,
     "wof:placetype":"locality",

--- a/data/101/794/663/101794663.geojson
+++ b/data/101/794/663/101794663.geojson
@@ -167,6 +167,9 @@
         "wk:page":"Bakar"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"29af15c9af89538f7865f1d957f17954",
     "wof:hierarchy":[
         {
@@ -180,7 +183,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647397,
+    "wof:lastmodified":1582318749,
     "wof:name":"Bakar",
     "wof:parent_id":85684789,
     "wof:placetype":"locality",

--- a/data/101/794/665/101794665.geojson
+++ b/data/101/794/665/101794665.geojson
@@ -104,6 +104,9 @@
         "wk:page":"Podhum, Croatia"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"25128fe1c632dd9d94d80f7da0b13fb0",
     "wof:hierarchy":[
         {
@@ -114,7 +117,7 @@
         }
     ],
     "wof:id":101794665,
-    "wof:lastmodified":1566647398,
+    "wof:lastmodified":1582318749,
     "wof:name":"Podhum",
     "wof:parent_id":85684789,
     "wof:placetype":"locality",

--- a/data/101/794/667/101794667.geojson
+++ b/data/101/794/667/101794667.geojson
@@ -107,6 +107,9 @@
         "wk:page":"Hreljin"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f40537ef62d339af123ede87a331f956",
     "wof:hierarchy":[
         {
@@ -117,7 +120,7 @@
         }
     ],
     "wof:id":101794667,
-    "wof:lastmodified":1566647393,
+    "wof:lastmodified":1582318748,
     "wof:name":"Hreljin",
     "wof:parent_id":85684789,
     "wof:placetype":"locality",

--- a/data/101/794/669/101794669.geojson
+++ b/data/101/794/669/101794669.geojson
@@ -143,6 +143,9 @@
         "wd:id":"Q396637"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f6f99e3c0adafe456aaa08363def2847",
     "wof:hierarchy":[
         {
@@ -156,7 +159,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647393,
+    "wof:lastmodified":1582318748,
     "wof:name":"Vrbovsko",
     "wof:parent_id":85684789,
     "wof:placetype":"locality",

--- a/data/101/794/675/101794675.geojson
+++ b/data/101/794/675/101794675.geojson
@@ -149,6 +149,9 @@
         "wk:page":"Delnice"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d9d4de46dc2de6b690f93b382640afbc",
     "wof:hierarchy":[
         {
@@ -162,7 +165,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647390,
+    "wof:lastmodified":1582318748,
     "wof:name":"Delnice",
     "wof:parent_id":85684789,
     "wof:placetype":"locality",

--- a/data/101/794/677/101794677.geojson
+++ b/data/101/794/677/101794677.geojson
@@ -104,6 +104,9 @@
         "wk:page":"Jadranovo"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ba38198ce937f8014f44d9f5480ba627",
     "wof:hierarchy":[
         {
@@ -114,7 +117,7 @@
         }
     ],
     "wof:id":101794677,
-    "wof:lastmodified":1566647396,
+    "wof:lastmodified":1582318749,
     "wof:name":"Jadranovo",
     "wof:parent_id":85684789,
     "wof:placetype":"locality",

--- a/data/101/794/679/101794679.geojson
+++ b/data/101/794/679/101794679.geojson
@@ -143,6 +143,9 @@
         "wk:page":"Lovran"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"365fe0e8e9db4acad717e30c318336ad",
     "wof:hierarchy":[
         {
@@ -153,7 +156,7 @@
         }
     ],
     "wof:id":101794679,
-    "wof:lastmodified":1566647396,
+    "wof:lastmodified":1582318749,
     "wof:name":"Lovran",
     "wof:parent_id":85684789,
     "wof:placetype":"locality",

--- a/data/101/794/681/101794681.geojson
+++ b/data/101/794/681/101794681.geojson
@@ -117,6 +117,9 @@
         "wk:page":"Nijemci"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1b9e474ae04184fee200cef0b685cc21",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647391,
+    "wof:lastmodified":1582318748,
     "wof:name":"Nijemci",
     "wof:parent_id":85684733,
     "wof:placetype":"locality",

--- a/data/101/794/683/101794683.geojson
+++ b/data/101/794/683/101794683.geojson
@@ -144,6 +144,9 @@
         "wk:page":"Otok, Vukovar-Srijem County"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e177ce2ece69fce066b47e4f4b39568e",
     "wof:hierarchy":[
         {
@@ -157,7 +160,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647396,
+    "wof:lastmodified":1582318749,
     "wof:name":"Otok",
     "wof:parent_id":85684733,
     "wof:placetype":"locality",

--- a/data/101/794/685/101794685.geojson
+++ b/data/101/794/685/101794685.geojson
@@ -86,6 +86,9 @@
         "wk:page":"Komletinci"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d2571ebd09e24f6e3cc82d2e839f78ae",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
         }
     ],
     "wof:id":101794685,
-    "wof:lastmodified":1566647395,
+    "wof:lastmodified":1582318749,
     "wof:name":"Komletinci",
     "wof:parent_id":85684733,
     "wof:placetype":"locality",

--- a/data/101/794/691/101794691.geojson
+++ b/data/101/794/691/101794691.geojson
@@ -92,6 +92,9 @@
         "wk:page":"\u0160titar, Croatia"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2303509fe0297e9d29225078d88a4d91",
     "wof:hierarchy":[
         {
@@ -102,7 +105,7 @@
         }
     ],
     "wof:id":101794691,
-    "wof:lastmodified":1566647398,
+    "wof:lastmodified":1582318749,
     "wof:name":"\u0160titar",
     "wof:parent_id":85684733,
     "wof:placetype":"locality",

--- a/data/101/794/693/101794693.geojson
+++ b/data/101/794/693/101794693.geojson
@@ -154,6 +154,9 @@
         "wd:id":"Q394310"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"630b62fa522576a954c02e053389d96b",
     "wof:hierarchy":[
         {
@@ -167,7 +170,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647393,
+    "wof:lastmodified":1582318748,
     "wof:name":"\u017dupanja",
     "wof:parent_id":85684733,
     "wof:placetype":"locality",

--- a/data/101/794/697/101794697.geojson
+++ b/data/101/794/697/101794697.geojson
@@ -102,6 +102,9 @@
         "wk:page":"Babina Greda"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"915ccdc8f1693d72591536220ee91811",
     "wof:hierarchy":[
         {
@@ -115,7 +118,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647397,
+    "wof:lastmodified":1582318749,
     "wof:name":"Babina Greda",
     "wof:parent_id":85684733,
     "wof:placetype":"locality",

--- a/data/101/794/701/101794701.geojson
+++ b/data/101/794/701/101794701.geojson
@@ -140,6 +140,9 @@
         "wk:page":"Soljani"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"37791e97dafbc835422bac7e24ff719f",
     "wof:hierarchy":[
         {
@@ -150,7 +153,7 @@
         }
     ],
     "wof:id":101794701,
-    "wof:lastmodified":1566647390,
+    "wof:lastmodified":1582318748,
     "wof:name":"Soljani",
     "wof:parent_id":85684733,
     "wof:placetype":"locality",

--- a/data/101/794/703/101794703.geojson
+++ b/data/101/794/703/101794703.geojson
@@ -107,6 +107,9 @@
         "wd:id":"Q1073850"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"fa7d54fed5064b42e5c9465e3a9a9ace",
     "wof:hierarchy":[
         {
@@ -120,7 +123,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647395,
+    "wof:lastmodified":1582318748,
     "wof:name":"Vrbanja",
     "wof:parent_id":85684733,
     "wof:placetype":"locality",

--- a/data/101/794/705/101794705.geojson
+++ b/data/101/794/705/101794705.geojson
@@ -102,6 +102,9 @@
         "qs_pg:id":95152
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ffed6ae2b415385ab601c8c7079ca068",
     "wof:hierarchy":[
         {
@@ -112,7 +115,7 @@
         }
     ],
     "wof:id":101794705,
-    "wof:lastmodified":1566647395,
+    "wof:lastmodified":1582318748,
     "wof:name":"Drenovci",
     "wof:parent_id":85684733,
     "wof:placetype":"locality",

--- a/data/101/794/709/101794709.geojson
+++ b/data/101/794/709/101794709.geojson
@@ -114,6 +114,9 @@
         "wk:page":"Gunja, Croatia"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"cc9980142850b2f0f3a072241c30cc35",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647390,
+    "wof:lastmodified":1582318748,
     "wof:name":"Gunja",
     "wof:parent_id":85684733,
     "wof:placetype":"locality",

--- a/data/101/794/715/101794715.geojson
+++ b/data/101/794/715/101794715.geojson
@@ -154,6 +154,9 @@
         "wk:page":"Hrvatska Kostajnica"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4beadf9633b69d551da0d02726452041",
     "wof:hierarchy":[
         {
@@ -168,7 +171,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647394,
+    "wof:lastmodified":1582318748,
     "wof:name":"Hrvatska Kostajnica",
     "wof:parent_id":1108759139,
     "wof:placetype":"locality",

--- a/data/101/794/717/101794717.geojson
+++ b/data/101/794/717/101794717.geojson
@@ -158,6 +158,9 @@
         "wk:page":"Glina, Croatia"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"65782989d16536bf2ece27c73400b08b",
     "wof:hierarchy":[
         {
@@ -171,7 +174,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647399,
+    "wof:lastmodified":1582318749,
     "wof:name":"Glina",
     "wof:parent_id":85684769,
     "wof:placetype":"locality",

--- a/data/101/794/719/101794719.geojson
+++ b/data/101/794/719/101794719.geojson
@@ -122,6 +122,9 @@
         "wk:page":"Pla\u0161ki"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"bc48ea52a4a19261d2b9d472350a3135",
     "wof:hierarchy":[
         {
@@ -132,7 +135,7 @@
         }
     ],
     "wof:id":101794719,
-    "wof:lastmodified":1566647399,
+    "wof:lastmodified":1582318749,
     "wof:name":"Pla\u0161ki",
     "wof:parent_id":85684819,
     "wof:placetype":"locality",

--- a/data/101/794/721/101794721.geojson
+++ b/data/101/794/721/101794721.geojson
@@ -149,6 +149,9 @@
         "wd:id":"Q397733"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b2b4a5dac52384081496e8d54f54f430",
     "wof:hierarchy":[
         {
@@ -162,7 +165,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647399,
+    "wof:lastmodified":1582318749,
     "wof:name":"Slunj",
     "wof:parent_id":85684819,
     "wof:placetype":"locality",

--- a/data/101/794/727/101794727.geojson
+++ b/data/101/794/727/101794727.geojson
@@ -122,6 +122,9 @@
         "wd:id":"Q615197"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f03f9cec69f63ebbcda37f8ac34c6d85",
     "wof:hierarchy":[
         {
@@ -135,7 +138,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647399,
+    "wof:lastmodified":1582318749,
     "wof:name":"Vojni\u0107",
     "wof:parent_id":85684819,
     "wof:placetype":"locality",

--- a/data/101/794/729/101794729.geojson
+++ b/data/101/794/729/101794729.geojson
@@ -161,6 +161,9 @@
         "wk:page":"Ogulin"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b6d8b86d1a4ad32349ef42325ac496e2",
     "wof:hierarchy":[
         {
@@ -174,7 +177,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647399,
+    "wof:lastmodified":1582318749,
     "wof:name":"Ogulin",
     "wof:parent_id":85684819,
     "wof:placetype":"locality",

--- a/data/101/795/727/101795727.geojson
+++ b/data/101/795/727/101795727.geojson
@@ -157,6 +157,9 @@
         "wd:id":"Q1151485"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ef7b15273caec7e98c2c7c4c19000ad3",
     "wof:hierarchy":[
         {
@@ -167,7 +170,7 @@
         }
     ],
     "wof:id":101795727,
-    "wof:lastmodified":1566647407,
+    "wof:lastmodified":1582318751,
     "wof:name":"Murter",
     "wof:parent_id":85684755,
     "wof:placetype":"locality",

--- a/data/101/795/729/101795729.geojson
+++ b/data/101/795/729/101795729.geojson
@@ -119,6 +119,9 @@
         "wd:id":"Q786883"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d65f1b6e632d7fcd01972df224662f4d",
     "wof:hierarchy":[
         {
@@ -132,7 +135,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647407,
+    "wof:lastmodified":1582318751,
     "wof:name":"Otok",
     "wof:parent_id":85684781,
     "wof:placetype":"locality",

--- a/data/101/795/731/101795731.geojson
+++ b/data/101/795/731/101795731.geojson
@@ -134,6 +134,9 @@
         "wk:page":"Trilj"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"77a7a42b0f9187d16a16d2e55fa944b8",
     "wof:hierarchy":[
         {
@@ -147,7 +150,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647402,
+    "wof:lastmodified":1582318750,
     "wof:name":"Trilj",
     "wof:parent_id":85684781,
     "wof:placetype":"locality",

--- a/data/101/795/735/101795735.geojson
+++ b/data/101/795/735/101795735.geojson
@@ -131,6 +131,9 @@
         "wk:page":"Ugljan"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ccc733a3247feadb68557cc85190b400",
     "wof:hierarchy":[
         {
@@ -141,7 +144,7 @@
         }
     ],
     "wof:id":101795735,
-    "wof:lastmodified":1566647405,
+    "wof:lastmodified":1582318750,
     "wof:name":"Ugljan",
     "wof:parent_id":85684807,
     "wof:placetype":"locality",

--- a/data/101/795/737/101795737.geojson
+++ b/data/101/795/737/101795737.geojson
@@ -208,6 +208,9 @@
         "wk:page":"Knin"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"38bf5ca695816763e0790d53e332a5bc",
     "wof:hierarchy":[
         {
@@ -218,7 +221,7 @@
         }
     ],
     "wof:id":101795737,
-    "wof:lastmodified":1566647402,
+    "wof:lastmodified":1582318750,
     "wof:name":"Knin",
     "wof:parent_id":85684755,
     "wof:placetype":"locality",

--- a/data/101/795/739/101795739.geojson
+++ b/data/101/795/739/101795739.geojson
@@ -163,6 +163,9 @@
         "qs_pg:id":279726
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b5bc20780c6ab7d0d3364649a81c46ef",
     "wof:hierarchy":[
         {
@@ -173,7 +176,7 @@
         }
     ],
     "wof:id":101795739,
-    "wof:lastmodified":1566647401,
+    "wof:lastmodified":1582318750,
     "wof:name":"Drni\u0161",
     "wof:parent_id":85684755,
     "wof:placetype":"locality",

--- a/data/101/795/741/101795741.geojson
+++ b/data/101/795/741/101795741.geojson
@@ -122,6 +122,9 @@
         "wk:page":"Pirovac"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"15fa8d45a8a574a1700a2dc3f064d54a",
     "wof:hierarchy":[
         {
@@ -132,7 +135,7 @@
         }
     ],
     "wof:id":101795741,
-    "wof:lastmodified":1566647404,
+    "wof:lastmodified":1582318750,
     "wof:name":"Pirovac",
     "wof:parent_id":85684755,
     "wof:placetype":"locality",

--- a/data/101/795/743/101795743.geojson
+++ b/data/101/795/743/101795743.geojson
@@ -114,6 +114,9 @@
         "wk:page":"Tribunj"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b743a743742ccadd11463efb171c1458",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":101795743,
-    "wof:lastmodified":1566647406,
+    "wof:lastmodified":1582318751,
     "wof:name":"Tribunj",
     "wof:parent_id":85684755,
     "wof:placetype":"locality",

--- a/data/101/795/745/101795745.geojson
+++ b/data/101/795/745/101795745.geojson
@@ -163,6 +163,9 @@
         "wk:page":"Vodice, Croatia"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a3ba97cbffa415b944b5f32a4a35ff9b",
     "wof:hierarchy":[
         {
@@ -173,7 +176,7 @@
         }
     ],
     "wof:id":101795745,
-    "wof:lastmodified":1566647407,
+    "wof:lastmodified":1582318751,
     "wof:name":"Vodice",
     "wof:parent_id":85684755,
     "wof:placetype":"locality",

--- a/data/101/795/747/101795747.geojson
+++ b/data/101/795/747/101795747.geojson
@@ -277,6 +277,9 @@
         "wd:id":"Q148333"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"bbbf0e530d47bca55798fb9cc60bdbf6",
     "wof:hierarchy":[
         {
@@ -287,7 +290,7 @@
         }
     ],
     "wof:id":101795747,
-    "wof:lastmodified":1566647403,
+    "wof:lastmodified":1582318750,
     "wof:name":"Zaton",
     "wof:parent_id":85684755,
     "wof:placetype":"locality",

--- a/data/101/795/749/101795749.geojson
+++ b/data/101/795/749/101795749.geojson
@@ -134,6 +134,9 @@
         "wk:page":"Vir"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8c3c5d4aaf215669bab56cf25062910a",
     "wof:hierarchy":[
         {
@@ -144,7 +147,7 @@
         }
     ],
     "wof:id":101795749,
-    "wof:lastmodified":1566647403,
+    "wof:lastmodified":1582318750,
     "wof:name":"Vir",
     "wof:parent_id":85684807,
     "wof:placetype":"locality",

--- a/data/101/795/755/101795755.geojson
+++ b/data/101/795/755/101795755.geojson
@@ -132,6 +132,9 @@
         "wk:page":"Starigrad, Zadar County"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c0f32a92199a822dc58c1cc6c8ee24fd",
     "wof:hierarchy":[
         {
@@ -142,7 +145,7 @@
         }
     ],
     "wof:id":101795755,
-    "wof:lastmodified":1566647401,
+    "wof:lastmodified":1582318750,
     "wof:name":"Starigrad",
     "wof:parent_id":85684807,
     "wof:placetype":"locality",

--- a/data/101/795/761/101795761.geojson
+++ b/data/101/795/761/101795761.geojson
@@ -122,6 +122,9 @@
         "wk:page":"Posedarje"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7e71db52a4da1e14d02480b454811857",
     "wof:hierarchy":[
         {
@@ -132,7 +135,7 @@
         }
     ],
     "wof:id":101795761,
-    "wof:lastmodified":1566647405,
+    "wof:lastmodified":1582318750,
     "wof:name":"Posedarje",
     "wof:parent_id":85684807,
     "wof:placetype":"locality",

--- a/data/101/795/763/101795763.geojson
+++ b/data/101/795/763/101795763.geojson
@@ -113,6 +113,9 @@
         "wk:page":"Poli\u010dnik"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7fccd9f3efea1e281b89229f8caa5d7b",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
         }
     ],
     "wof:id":101795763,
-    "wof:lastmodified":1566647401,
+    "wof:lastmodified":1582318750,
     "wof:name":"Poli\u010dnik",
     "wof:parent_id":85684807,
     "wof:placetype":"locality",

--- a/data/101/795/765/101795765.geojson
+++ b/data/101/795/765/101795765.geojson
@@ -170,6 +170,9 @@
         "wk:page":"Biograd na Moru"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d688ac4fa48e2668093fff24f250d4d6",
     "wof:hierarchy":[
         {
@@ -180,7 +183,7 @@
         }
     ],
     "wof:id":101795765,
-    "wof:lastmodified":1566647402,
+    "wof:lastmodified":1582318750,
     "wof:name":"Biograd na moru",
     "wof:parent_id":85684807,
     "wof:placetype":"locality",

--- a/data/101/795/767/101795767.geojson
+++ b/data/101/795/767/101795767.geojson
@@ -145,6 +145,9 @@
         "wk:page":"Benkovac"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0e0a69ac718469dde4fdee6a92ea27bc",
     "wof:hierarchy":[
         {
@@ -155,7 +158,7 @@
         }
     ],
     "wof:id":101795767,
-    "wof:lastmodified":1566647404,
+    "wof:lastmodified":1582318750,
     "wof:name":"Benkovac",
     "wof:parent_id":85684807,
     "wof:placetype":"locality",

--- a/data/101/795/771/101795771.geojson
+++ b/data/101/795/771/101795771.geojson
@@ -123,6 +123,9 @@
         "qs_pg:id":1044097
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c01f0431ad1e13e38a15eb08e76d49d4",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
         }
     ],
     "wof:id":101795771,
-    "wof:lastmodified":1566647403,
+    "wof:lastmodified":1582318750,
     "wof:name":"Privlaka",
     "wof:parent_id":85684807,
     "wof:placetype":"locality",

--- a/data/101/795/773/101795773.geojson
+++ b/data/101/795/773/101795773.geojson
@@ -165,6 +165,9 @@
         "wk:page":"Nin, Croatia"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"84279b245add6552225e525f1a3113c7",
     "wof:hierarchy":[
         {
@@ -175,7 +178,7 @@
         }
     ],
     "wof:id":101795773,
-    "wof:lastmodified":1566647406,
+    "wof:lastmodified":1582318751,
     "wof:name":"Nin",
     "wof:parent_id":85684807,
     "wof:placetype":"locality",

--- a/data/101/795/775/101795775.geojson
+++ b/data/101/795/775/101795775.geojson
@@ -104,6 +104,9 @@
         "wk:page":"Vrsi"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"07e61b5043cb941af4248d558b4a8e80",
     "wof:hierarchy":[
         {
@@ -114,7 +117,7 @@
         }
     ],
     "wof:id":101795775,
-    "wof:lastmodified":1566647406,
+    "wof:lastmodified":1582318751,
     "wof:name":"Vrsi",
     "wof:parent_id":85684807,
     "wof:placetype":"locality",

--- a/data/101/795/777/101795777.geojson
+++ b/data/101/795/777/101795777.geojson
@@ -110,6 +110,9 @@
         "wk:page":"Ra\u017eanac"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b342178141d9ba662ce4425ad7830b20",
     "wof:hierarchy":[
         {
@@ -120,7 +123,7 @@
         }
     ],
     "wof:id":101795777,
-    "wof:lastmodified":1566647404,
+    "wof:lastmodified":1582318750,
     "wof:name":"Ra\u017eanac",
     "wof:parent_id":85684807,
     "wof:placetype":"locality",

--- a/data/101/795/779/101795779.geojson
+++ b/data/101/795/779/101795779.geojson
@@ -145,6 +145,9 @@
         "wk:page":"Obrovac, Croatia"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"beaa646c4ad5bb9e3c1bd4fb99fe22b9",
     "wof:hierarchy":[
         {
@@ -155,7 +158,7 @@
         }
     ],
     "wof:id":101795779,
-    "wof:lastmodified":1566647404,
+    "wof:lastmodified":1582318750,
     "wof:name":"Obrovac",
     "wof:parent_id":85684807,
     "wof:placetype":"locality",

--- a/data/101/795/785/101795785.geojson
+++ b/data/101/795/785/101795785.geojson
@@ -153,6 +153,9 @@
         "wk:page":"Oto\u010dac"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b8a396be6fd82c5099c0a336e7f3fc6f",
     "wof:hierarchy":[
         {
@@ -166,7 +169,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647403,
+    "wof:lastmodified":1582318750,
     "wof:name":"Oto\u010dac",
     "wof:parent_id":85684737,
     "wof:placetype":"locality",

--- a/data/101/795/789/101795789.geojson
+++ b/data/101/795/789/101795789.geojson
@@ -112,6 +112,9 @@
         "qs_pg:id":983679
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"894e5c36166865ea4457a82043fcd7fd",
     "wof:hierarchy":[
         {
@@ -122,7 +125,7 @@
         }
     ],
     "wof:id":101795789,
-    "wof:lastmodified":1566647407,
+    "wof:lastmodified":1582318751,
     "wof:name":"Korenica",
     "wof:parent_id":85684737,
     "wof:placetype":"locality",

--- a/data/101/795/793/101795793.geojson
+++ b/data/101/795/793/101795793.geojson
@@ -196,6 +196,9 @@
         "wk:page":"Senj"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"faafff8f5f814af51c15d951547ecfdb",
     "wof:hierarchy":[
         {
@@ -209,7 +212,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647404,
+    "wof:lastmodified":1582318750,
     "wof:name":"Senj",
     "wof:parent_id":85684737,
     "wof:placetype":"locality",

--- a/data/101/795/795/101795795.geojson
+++ b/data/101/795/795/101795795.geojson
@@ -210,6 +210,9 @@
         "wk:page":"Gospi\u0107"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"246e71195c1445a10c92071337b6bf16",
     "wof:hierarchy":[
         {
@@ -223,7 +226,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647405,
+    "wof:lastmodified":1582318750,
     "wof:name":"Gospi\u0107",
     "wof:parent_id":85684737,
     "wof:placetype":"locality",

--- a/data/101/795/797/101795797.geojson
+++ b/data/101/795/797/101795797.geojson
@@ -237,6 +237,9 @@
         "wk:page":"Cres"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"222c8964b440122ec172eeafbc69dddf",
     "wof:hierarchy":[
         {
@@ -250,7 +253,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647401,
+    "wof:lastmodified":1582318750,
     "wof:name":"Cres",
     "wof:parent_id":85684789,
     "wof:placetype":"locality",

--- a/data/101/795/799/101795799.geojson
+++ b/data/101/795/799/101795799.geojson
@@ -125,6 +125,9 @@
         "wk:page":"Punat"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"05740a9f5daf5dd71cd2399c3e4a1454",
     "wof:hierarchy":[
         {
@@ -138,7 +141,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647401,
+    "wof:lastmodified":1582318750,
     "wof:name":"Punat",
     "wof:parent_id":85684789,
     "wof:placetype":"locality",

--- a/data/101/795/801/101795801.geojson
+++ b/data/101/795/801/101795801.geojson
@@ -95,6 +95,9 @@
         "wk:page":"Gali\u017eana"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3cbcfe3af2244c77c2e47ea76ce27f55",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
         }
     ],
     "wof:id":101795801,
-    "wof:lastmodified":1566647406,
+    "wof:lastmodified":1582318751,
     "wof:name":"Gali\u017eana",
     "wof:parent_id":85684829,
     "wof:placetype":"locality",

--- a/data/101/795/803/101795803.geojson
+++ b/data/101/795/803/101795803.geojson
@@ -239,6 +239,9 @@
         "wk:page":"Rovinj"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0ef7c343a74cd53e2a67ffcd815f9c85",
     "wof:hierarchy":[
         {
@@ -252,7 +255,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647403,
+    "wof:lastmodified":1582318750,
     "wof:name":"Rovinj",
     "wof:parent_id":85684829,
     "wof:placetype":"locality",

--- a/data/101/795/807/101795807.geojson
+++ b/data/101/795/807/101795807.geojson
@@ -121,6 +121,9 @@
         "wk:page":"Mar\u010dana"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"10d516bcfdabc3b844012a6b400433c2",
     "wof:hierarchy":[
         {
@@ -134,7 +137,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647406,
+    "wof:lastmodified":1582318750,
     "wof:name":"Mar\u010dana",
     "wof:parent_id":85684829,
     "wof:placetype":"locality",

--- a/data/101/795/809/101795809.geojson
+++ b/data/101/795/809/101795809.geojson
@@ -150,6 +150,9 @@
         "wk:page":"Vodnjan"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b781fa8c97b4846eefcddc55e41277ec",
     "wof:hierarchy":[
         {
@@ -163,7 +166,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647406,
+    "wof:lastmodified":1582318751,
     "wof:name":"Vodnjan",
     "wof:parent_id":85684829,
     "wof:placetype":"locality",

--- a/data/101/795/811/101795811.geojson
+++ b/data/101/795/811/101795811.geojson
@@ -136,6 +136,9 @@
         "wk:page":"Medulin"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"eb90c1d65452dbe337922fdfb78a7a73",
     "wof:hierarchy":[
         {
@@ -149,7 +152,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647403,
+    "wof:lastmodified":1582318750,
     "wof:name":"Medulin",
     "wof:parent_id":85684829,
     "wof:placetype":"locality",

--- a/data/101/795/813/101795813.geojson
+++ b/data/101/795/813/101795813.geojson
@@ -128,6 +128,9 @@
         "wk:page":"Fa\u017eana"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ba1b3fbacda9ea237e463b63cba06656",
     "wof:hierarchy":[
         {
@@ -141,7 +144,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647405,
+    "wof:lastmodified":1582318750,
     "wof:name":"Fa\u017eana",
     "wof:parent_id":85684829,
     "wof:placetype":"locality",

--- a/data/101/796/853/101796853.geojson
+++ b/data/101/796/853/101796853.geojson
@@ -133,6 +133,9 @@
         "wk:page":"Vela Luka"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0beb602d017a7260a579fc499a286d07",
     "wof:hierarchy":[
         {
@@ -146,7 +149,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647351,
+    "wof:lastmodified":1582318742,
     "wof:name":"Vela Luka",
     "wof:parent_id":85684775,
     "wof:placetype":"locality",

--- a/data/101/796/855/101796855.geojson
+++ b/data/101/796/855/101796855.geojson
@@ -117,6 +117,9 @@
         "qs_pg:id":1274858
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5b4e2d6ebefdea231794917cc7a67ade",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":101796855,
-    "wof:lastmodified":1566647351,
+    "wof:lastmodified":1582318742,
     "wof:name":"Blato",
     "wof:parent_id":85684775,
     "wof:placetype":"locality",

--- a/data/101/796/857/101796857.geojson
+++ b/data/101/796/857/101796857.geojson
@@ -117,6 +117,9 @@
         "wk:page":"Smokvica"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8bf85b939952d0dc5ca6607452d57791",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647349,
+    "wof:lastmodified":1582318741,
     "wof:name":"Smokvica",
     "wof:parent_id":85684775,
     "wof:placetype":"locality",

--- a/data/101/796/859/101796859.geojson
+++ b/data/101/796/859/101796859.geojson
@@ -117,6 +117,9 @@
         "wk:page":"Lumbarda"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5417d03bc4b30ce81cebca73a1042e65",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647348,
+    "wof:lastmodified":1582318741,
     "wof:name":"Lumbarda",
     "wof:parent_id":85684775,
     "wof:placetype":"locality",

--- a/data/101/796/861/101796861.geojson
+++ b/data/101/796/861/101796861.geojson
@@ -92,6 +92,9 @@
         "wk:page":"\u017drnovo"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5f3d4c25580a2167d5c218829ac71844",
     "wof:hierarchy":[
         {
@@ -102,7 +105,7 @@
         }
     ],
     "wof:id":101796861,
-    "wof:lastmodified":1566647348,
+    "wof:lastmodified":1582318741,
     "wof:name":"\u017drnovo",
     "wof:parent_id":85684775,
     "wof:placetype":"locality",

--- a/data/101/796/863/101796863.geojson
+++ b/data/101/796/863/101796863.geojson
@@ -188,6 +188,9 @@
         "wk:page":"Kor\u010dula (town)"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e1040eba34586ebc855ccb6654d4ef73",
     "wof:hierarchy":[
         {
@@ -201,7 +204,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647352,
+    "wof:lastmodified":1582318742,
     "wof:name":"Kor\u010dula",
     "wof:parent_id":85684785,
     "wof:placetype":"locality",

--- a/data/101/796/865/101796865.geojson
+++ b/data/101/796/865/101796865.geojson
@@ -176,6 +176,9 @@
         "wk:page":"Komi\u017ea"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"959e9dade030a3900f9d942a078cb9ce",
     "wof:hierarchy":[
         {
@@ -189,7 +192,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647351,
+    "wof:lastmodified":1582318742,
     "wof:name":"Komi\u017ea",
     "wof:parent_id":85684781,
     "wof:placetype":"locality",

--- a/data/101/796/871/101796871.geojson
+++ b/data/101/796/871/101796871.geojson
@@ -130,6 +130,9 @@
         "wk:page":"Orebi\u0107"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ee1a27003f5cf0cd8e7119b23c4eed63",
     "wof:hierarchy":[
         {
@@ -143,7 +146,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647350,
+    "wof:lastmodified":1582318741,
     "wof:name":"Orebi\u0107",
     "wof:parent_id":85684775,
     "wof:placetype":"locality",

--- a/data/101/796/873/101796873.geojson
+++ b/data/101/796/873/101796873.geojson
@@ -182,6 +182,9 @@
         "wk:page":"Hvar (city)"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"914766bc8c84b2bf57022139dd7325ee",
     "wof:hierarchy":[
         {
@@ -195,7 +198,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647347,
+    "wof:lastmodified":1582318741,
     "wof:name":"Hvar",
     "wof:parent_id":85684781,
     "wof:placetype":"locality",

--- a/data/101/796/875/101796875.geojson
+++ b/data/101/796/875/101796875.geojson
@@ -185,6 +185,9 @@
         "wk:page":"Metkovi\u0107"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9e1376390fa390194cf7cb0ae84082d8",
     "wof:hierarchy":[
         {
@@ -198,7 +201,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647348,
+    "wof:lastmodified":1582318741,
     "wof:name":"Metkovi\u0107",
     "wof:parent_id":85684775,
     "wof:placetype":"locality",

--- a/data/101/796/877/101796877.geojson
+++ b/data/101/796/877/101796877.geojson
@@ -155,6 +155,9 @@
         "wk:page":"Opuzen"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8e69ba59008b8ad8e845a5df51563832",
     "wof:hierarchy":[
         {
@@ -168,7 +171,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647350,
+    "wof:lastmodified":1582318741,
     "wof:name":"Opuzen",
     "wof:parent_id":85684775,
     "wof:placetype":"locality",

--- a/data/101/796/879/101796879.geojson
+++ b/data/101/796/879/101796879.geojson
@@ -175,6 +175,9 @@
         "wd:id":"Q115117"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c2dc27a43bc6dcedb15fee34a370dc41",
     "wof:hierarchy":[
         {
@@ -188,7 +191,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647350,
+    "wof:lastmodified":1582318741,
     "wof:name":"Plo\u010de",
     "wof:parent_id":85684775,
     "wof:placetype":"locality",

--- a/data/101/796/881/101796881.geojson
+++ b/data/101/796/881/101796881.geojson
@@ -143,6 +143,9 @@
         "wk:page":"Bol, Croatia"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c6f2785a0f3a4faaa7e67fc08ca83c68",
     "wof:hierarchy":[
         {
@@ -156,7 +159,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647348,
+    "wof:lastmodified":1582318741,
     "wof:name":"Bol",
     "wof:parent_id":85684781,
     "wof:placetype":"locality",

--- a/data/101/796/883/101796883.geojson
+++ b/data/101/796/883/101796883.geojson
@@ -135,6 +135,9 @@
         "wk:page":"Postira"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d13f07dfb08c11d6774d52cdbbbdb588",
     "wof:hierarchy":[
         {
@@ -148,7 +151,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647350,
+    "wof:lastmodified":1582318741,
     "wof:name":"Postira",
     "wof:parent_id":85684781,
     "wof:placetype":"locality",

--- a/data/101/796/887/101796887.geojson
+++ b/data/101/796/887/101796887.geojson
@@ -111,6 +111,9 @@
         "wk:page":"Marina, Croatia"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"88ef9ba5199b99de93530d9378ca8854",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":101796887,
-    "wof:lastmodified":1566647347,
+    "wof:lastmodified":1582318741,
     "wof:name":"Marina",
     "wof:parent_id":85684781,
     "wof:placetype":"locality",

--- a/data/101/796/889/101796889.geojson
+++ b/data/101/796/889/101796889.geojson
@@ -126,6 +126,9 @@
         "wk:page":"Dugopolje"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ea78451c484cba4e2173812df881decb",
     "wof:hierarchy":[
         {
@@ -139,7 +142,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647347,
+    "wof:lastmodified":1582318741,
     "wof:name":"Dugopolje",
     "wof:parent_id":85684781,
     "wof:placetype":"locality",

--- a/data/101/796/891/101796891.geojson
+++ b/data/101/796/891/101796891.geojson
@@ -118,6 +118,9 @@
         "wk:page":"Zmijavci"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7f12c5b9c4b180d5084b97ced8460eed",
     "wof:hierarchy":[
         {
@@ -131,7 +134,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647351,
+    "wof:lastmodified":1582318742,
     "wof:name":"Zmijavci",
     "wof:parent_id":85684781,
     "wof:placetype":"locality",

--- a/data/101/796/893/101796893.geojson
+++ b/data/101/796/893/101796893.geojson
@@ -104,6 +104,9 @@
         "qs_pg:id":1275501
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"fbd3d48843b7f3789abf2998d6b03917",
     "wof:hierarchy":[
         {
@@ -114,7 +117,7 @@
         }
     ],
     "wof:id":101796893,
-    "wof:lastmodified":1566647349,
+    "wof:lastmodified":1582318741,
     "wof:name":"Runovi\u0107",
     "wof:parent_id":85684781,
     "wof:placetype":"locality",

--- a/data/101/796/897/101796897.geojson
+++ b/data/101/796/897/101796897.geojson
@@ -81,6 +81,9 @@
         "wd:id":"Q5274828"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c6ce775426968da6de5b0f72a36c7d00",
     "wof:hierarchy":[
         {
@@ -91,7 +94,7 @@
         }
     ],
     "wof:id":101796897,
-    "wof:lastmodified":1566647352,
+    "wof:lastmodified":1582318742,
     "wof:name":"Grubine",
     "wof:parent_id":85684781,
     "wof:placetype":"locality",

--- a/data/101/796/899/101796899.geojson
+++ b/data/101/796/899/101796899.geojson
@@ -337,6 +337,9 @@
         "wd:id":"Q272009"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6a26f0787f59158303fd2c012336b55b",
     "wof:hierarchy":[
         {
@@ -350,7 +353,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647351,
+    "wof:lastmodified":1582318742,
     "wof:name":"Makarska",
     "wof:parent_id":85684781,
     "wof:placetype":"locality",

--- a/data/101/796/901/101796901.geojson
+++ b/data/101/796/901/101796901.geojson
@@ -139,6 +139,9 @@
         "wk:page":"Podgora, Split-Dalmatia County"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8611b2dac9400482668dabb76315908f",
     "wof:hierarchy":[
         {
@@ -152,7 +155,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647347,
+    "wof:lastmodified":1582318741,
     "wof:name":"Podgora",
     "wof:parent_id":85684781,
     "wof:placetype":"locality",

--- a/data/101/796/905/101796905.geojson
+++ b/data/101/796/905/101796905.geojson
@@ -86,6 +86,9 @@
         "wk:page":"Mravince"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"08df79548672864f4757166e4da2a999",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
         }
     ],
     "wof:id":101796905,
-    "wof:lastmodified":1566647350,
+    "wof:lastmodified":1582318741,
     "wof:name":"Mravince",
     "wof:parent_id":85684781,
     "wof:placetype":"locality",

--- a/data/101/796/907/101796907.geojson
+++ b/data/101/796/907/101796907.geojson
@@ -124,6 +124,9 @@
         "wk:page":"Gradac, Split-Dalmatia County"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5ddd8fe7eac0e88ff302e6cd54892ca9",
     "wof:hierarchy":[
         {
@@ -137,7 +140,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647347,
+    "wof:lastmodified":1582318741,
     "wof:name":"Gradac",
     "wof:parent_id":85684781,
     "wof:placetype":"locality",

--- a/data/101/796/911/101796911.geojson
+++ b/data/101/796/911/101796911.geojson
@@ -181,6 +181,9 @@
         "qs_pg:id":1044098
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b6572dd3d34f30cc1672860df2d76878",
     "wof:hierarchy":[
         {
@@ -191,7 +194,7 @@
         }
     ],
     "wof:id":101796911,
-    "wof:lastmodified":1566647352,
+    "wof:lastmodified":1582318742,
     "wof:name":"Stari Grad",
     "wof:parent_id":85684781,
     "wof:placetype":"locality",

--- a/data/101/797/977/101797977.geojson
+++ b/data/101/797/977/101797977.geojson
@@ -482,6 +482,9 @@
         "wk:page":"Dubrovnik"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f8f23701eaad0d328bcdb81f8d9d0f6f",
     "wof:hierarchy":[
         {
@@ -495,7 +498,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647333,
+    "wof:lastmodified":1582318740,
     "wof:name":"Dubrovnik",
     "wof:parent_id":85684775,
     "wof:placetype":"locality",

--- a/data/101/834/349/101834349.geojson
+++ b/data/101/834/349/101834349.geojson
@@ -231,6 +231,9 @@
         "wk:page":"Koprivnica"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5990769e55cce762a92d357f81cab91f",
     "wof:hierarchy":[
         {
@@ -244,7 +247,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647375,
+    "wof:lastmodified":1582318745,
     "wof:name":"Koprivnica",
     "wof:parent_id":85684799,
     "wof:placetype":"locality",

--- a/data/101/834/357/101834357.geojson
+++ b/data/101/834/357/101834357.geojson
@@ -111,6 +111,9 @@
         "wk:page":"Vinica, Vara\u017edin County"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3be813cb01d247ddf500c8ea575770bd",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647376,
+    "wof:lastmodified":1582318745,
     "wof:name":"Vinica",
     "wof:parent_id":85684835,
     "wof:placetype":"locality",

--- a/data/101/834/359/101834359.geojson
+++ b/data/101/834/359/101834359.geojson
@@ -277,6 +277,9 @@
         "wk:page":"Vara\u017edin County (former)"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"dc5fc84b6019bbf57eee8d79820d8728",
     "wof:hierarchy":[
         {
@@ -290,7 +293,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647376,
+    "wof:lastmodified":1582318745,
     "wof:name":"Vara\u017edin",
     "wof:parent_id":85684835,
     "wof:placetype":"locality",

--- a/data/101/834/365/101834365.geojson
+++ b/data/101/834/365/101834365.geojson
@@ -93,6 +93,9 @@
         "wk:page":"Jalkovec"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c749bf59ea2ed38a70cb17ed2ec49b8f",
     "wof:hierarchy":[
         {
@@ -106,7 +109,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647374,
+    "wof:lastmodified":1582318745,
     "wof:name":"Jalkovec",
     "wof:parent_id":85684835,
     "wof:placetype":"locality",

--- a/data/101/834/367/101834367.geojson
+++ b/data/101/834/367/101834367.geojson
@@ -114,6 +114,9 @@
         "wk:page":"Sra\u010dinec"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"11539c51285643cd2e91ff72cfa8a155",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647376,
+    "wof:lastmodified":1582318746,
     "wof:name":"Sra\u010dinec",
     "wof:parent_id":85684835,
     "wof:placetype":"locality",

--- a/data/101/834/369/101834369.geojson
+++ b/data/101/834/369/101834369.geojson
@@ -114,6 +114,9 @@
         "wk:page":"Petrijanec"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"14d33a2e86d750bba46c0d88be31d8fe",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647376,
+    "wof:lastmodified":1582318746,
     "wof:name":"Petrijanec",
     "wof:parent_id":85684835,
     "wof:placetype":"locality",

--- a/data/101/834/371/101834371.geojson
+++ b/data/101/834/371/101834371.geojson
@@ -223,6 +223,9 @@
         "wk:page":"\u010cakovec"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2b226d50b4be93a41b0bb15c9c6eb7c5",
     "wof:hierarchy":[
         {
@@ -233,7 +236,7 @@
         }
     ],
     "wof:id":101834371,
-    "wof:lastmodified":1566647375,
+    "wof:lastmodified":1582318745,
     "wof:name":"\u010cakovec",
     "wof:parent_id":85684823,
     "wof:placetype":"locality",

--- a/data/101/834/375/101834375.geojson
+++ b/data/101/834/375/101834375.geojson
@@ -111,6 +111,9 @@
         "wk:page":"\u0160enkovec"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3692e9d54ab5131c34c6676bb2e401d9",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":101834375,
-    "wof:lastmodified":1566647377,
+    "wof:lastmodified":1582318746,
     "wof:name":"\u0160enkovec",
     "wof:parent_id":85684823,
     "wof:placetype":"locality",

--- a/data/101/834/377/101834377.geojson
+++ b/data/101/834/377/101834377.geojson
@@ -110,6 +110,9 @@
         "wk:page":"Strahoninec"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"017c7b5dc1dc94c75b52efeda5131888",
     "wof:hierarchy":[
         {
@@ -120,7 +123,7 @@
         }
     ],
     "wof:id":101834377,
-    "wof:lastmodified":1566647375,
+    "wof:lastmodified":1582318745,
     "wof:name":"Strahoninec",
     "wof:parent_id":85684823,
     "wof:placetype":"locality",

--- a/data/101/834/381/101834381.geojson
+++ b/data/101/834/381/101834381.geojson
@@ -110,6 +110,9 @@
         "wk:page":"Pribislavec"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6367ad25b9792aad27a292ed2c37b062",
     "wof:hierarchy":[
         {
@@ -120,7 +123,7 @@
         }
     ],
     "wof:id":101834381,
-    "wof:lastmodified":1566647377,
+    "wof:lastmodified":1582318746,
     "wof:name":"Pribislavec",
     "wof:parent_id":85684823,
     "wof:placetype":"locality",

--- a/data/101/834/383/101834383.geojson
+++ b/data/101/834/383/101834383.geojson
@@ -120,6 +120,9 @@
         "wk:page":"Nedeli\u0161\u0107e"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1e4c60f1e5d69e1e10c0cd12fa6fba39",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":101834383,
-    "wof:lastmodified":1566647375,
+    "wof:lastmodified":1582318745,
     "wof:name":"Nedeli\u0161\u0107e",
     "wof:parent_id":85684823,
     "wof:placetype":"locality",

--- a/data/101/835/283/101835283.geojson
+++ b/data/101/835/283/101835283.geojson
@@ -83,6 +83,9 @@
         "wk:page":"Lu\u017eani, Brod-Posavina County"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4426addd873e6303522d18229c6303cc",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
         }
     ],
     "wof:id":101835283,
-    "wof:lastmodified":1566647371,
+    "wof:lastmodified":1582318745,
     "wof:name":"Lu\u017eani",
     "wof:parent_id":85684749,
     "wof:placetype":"locality",

--- a/data/101/835/285/101835285.geojson
+++ b/data/101/835/285/101835285.geojson
@@ -105,6 +105,9 @@
         "wk:page":"Oriovac"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"bcf3b9392b08bd04390b05950697d554",
     "wof:hierarchy":[
         {
@@ -118,7 +121,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647372,
+    "wof:lastmodified":1582318745,
     "wof:name":"Oriovac",
     "wof:parent_id":85684749,
     "wof:placetype":"locality",

--- a/data/101/835/291/101835291.geojson
+++ b/data/101/835/291/101835291.geojson
@@ -108,6 +108,9 @@
         "wk:page":"Cernik, Brod-Posavina County"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2d1f76c1dba137b4b2bf72df8168cdbd",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647372,
+    "wof:lastmodified":1582318745,
     "wof:name":"Cernik",
     "wof:parent_id":85684749,
     "wof:placetype":"locality",

--- a/data/101/835/295/101835295.geojson
+++ b/data/101/835/295/101835295.geojson
@@ -150,6 +150,9 @@
         "wd:id":"Q58342"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0a3dbc93082cccf9d369ca4ba5276bb9",
     "wof:hierarchy":[
         {
@@ -160,7 +163,7 @@
         }
     ],
     "wof:id":101835295,
-    "wof:lastmodified":1566647367,
+    "wof:lastmodified":1582318744,
     "wof:name":"Ljupina",
     "wof:parent_id":85684749,
     "wof:placetype":"locality",

--- a/data/101/835/301/101835301.geojson
+++ b/data/101/835/301/101835301.geojson
@@ -89,6 +89,9 @@
         "wk:page":"Vidovci"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7a5c3fc3ba89e552ce2155e1ef5b2a1a",
     "wof:hierarchy":[
         {
@@ -99,7 +102,7 @@
         }
     ],
     "wof:id":101835301,
-    "wof:lastmodified":1566647365,
+    "wof:lastmodified":1582318744,
     "wof:name":"Vidovci",
     "wof:parent_id":85684763,
     "wof:placetype":"locality",

--- a/data/101/835/303/101835303.geojson
+++ b/data/101/835/303/101835303.geojson
@@ -140,6 +140,9 @@
         "wk:page":"Pleternica"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"417baf92c9db7eec6ead8421f6fd81fb",
     "wof:hierarchy":[
         {
@@ -153,7 +156,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647370,
+    "wof:lastmodified":1582318745,
     "wof:name":"Pleternica",
     "wof:parent_id":85684763,
     "wof:placetype":"locality",

--- a/data/101/835/305/101835305.geojson
+++ b/data/101/835/305/101835305.geojson
@@ -157,6 +157,9 @@
         "wk:page":"Lipik"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"56a087989d519e13258aaf31f78062c0",
     "wof:hierarchy":[
         {
@@ -170,7 +173,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647371,
+    "wof:lastmodified":1582318745,
     "wof:name":"Lipik",
     "wof:parent_id":85684763,
     "wof:placetype":"locality",

--- a/data/101/835/307/101835307.geojson
+++ b/data/101/835/307/101835307.geojson
@@ -175,6 +175,9 @@
         "wd:id":"Q398115"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"569ceb426c889db4f07cf1b992b21979",
     "wof:hierarchy":[
         {
@@ -188,7 +191,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647364,
+    "wof:lastmodified":1582318744,
     "wof:name":"Pakrac",
     "wof:parent_id":85684763,
     "wof:placetype":"locality",

--- a/data/101/835/309/101835309.geojson
+++ b/data/101/835/309/101835309.geojson
@@ -282,6 +282,9 @@
         "qs_pg:id":1174971
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9775b1b6f0ea10904470e1768636ba30",
     "wof:hierarchy":[
         {
@@ -295,7 +298,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647364,
+    "wof:lastmodified":1582318744,
     "wof:name":"Po\u017eega",
     "wof:parent_id":85684763,
     "wof:placetype":"locality",

--- a/data/101/835/317/101835317.geojson
+++ b/data/101/835/317/101835317.geojson
@@ -100,6 +100,9 @@
         "wd:id":"Q1061110"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d91811e71db20c7dd6f253bc1a21d60c",
     "wof:hierarchy":[
         {
@@ -110,7 +113,7 @@
         }
     ],
     "wof:id":101835317,
-    "wof:lastmodified":1566647373,
+    "wof:lastmodified":1582318745,
     "wof:name":"Mirkovci",
     "wof:parent_id":85684733,
     "wof:placetype":"locality",

--- a/data/101/835/319/101835319.geojson
+++ b/data/101/835/319/101835319.geojson
@@ -99,6 +99,9 @@
         "wk:page":"Stari Jankovci"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7f8fbeab5f82ac47410dc2b0a23d91d4",
     "wof:hierarchy":[
         {
@@ -112,7 +115,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647373,
+    "wof:lastmodified":1582318745,
     "wof:name":"Stari Jankovci",
     "wof:parent_id":85684733,
     "wof:placetype":"locality",

--- a/data/101/835/323/101835323.geojson
+++ b/data/101/835/323/101835323.geojson
@@ -130,6 +130,9 @@
         "wk:page":"Borovo, Croatia"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e8d1ca6b3c16911d5c97931220145bd0",
     "wof:hierarchy":[
         {
@@ -143,7 +146,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647368,
+    "wof:lastmodified":1582318745,
     "wof:name":"Borovo",
     "wof:parent_id":85684733,
     "wof:placetype":"locality",

--- a/data/101/835/325/101835325.geojson
+++ b/data/101/835/325/101835325.geojson
@@ -244,6 +244,9 @@
         "wd:id":"Q5867"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8d0dec4b7960885956caa22a9dfe1398",
     "wof:hierarchy":[
         {
@@ -257,7 +260,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647369,
+    "wof:lastmodified":1582318745,
     "wof:name":"Vukovar",
     "wof:parent_id":85684733,
     "wof:placetype":"locality",

--- a/data/101/835/327/101835327.geojson
+++ b/data/101/835/327/101835327.geojson
@@ -86,6 +86,9 @@
         "wk:page":"Rokovci"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"cddd9b504d8ea3abc51983d988dde37c",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
         }
     ],
     "wof:id":101835327,
-    "wof:lastmodified":1566647373,
+    "wof:lastmodified":1582318745,
     "wof:name":"Rokovci",
     "wof:parent_id":85684733,
     "wof:placetype":"locality",

--- a/data/101/835/339/101835339.geojson
+++ b/data/101/835/339/101835339.geojson
@@ -92,6 +92,9 @@
         "wk:page":"Buda\u0161evo"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d0bc8620a7b9b9a42768974ba2766032",
     "wof:hierarchy":[
         {
@@ -102,7 +105,7 @@
         }
     ],
     "wof:id":101835339,
-    "wof:lastmodified":1566647365,
+    "wof:lastmodified":1582318744,
     "wof:name":"Buda\u0161evo",
     "wof:parent_id":85684769,
     "wof:placetype":"locality",

--- a/data/101/835/341/101835341.geojson
+++ b/data/101/835/341/101835341.geojson
@@ -60,6 +60,9 @@
         "qs_pg:id":1275100
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d8f1e7327a2640ab4ddf4a02ed176329",
     "wof:hierarchy":[
         {
@@ -70,7 +73,7 @@
         }
     ],
     "wof:id":101835341,
-    "wof:lastmodified":1566647367,
+    "wof:lastmodified":1582318744,
     "wof:name":"Husain",
     "wof:parent_id":85684769,
     "wof:placetype":"locality",

--- a/data/101/835/345/101835345.geojson
+++ b/data/101/835/345/101835345.geojson
@@ -164,6 +164,9 @@
         "wd:id":"Q396536"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"52cddd19ea03aba7fd027e1885e5ae79",
     "wof:hierarchy":[
         {
@@ -177,7 +180,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647373,
+    "wof:lastmodified":1582318745,
     "wof:name":"Kutina",
     "wof:parent_id":85684769,
     "wof:placetype":"locality",

--- a/data/101/835/349/101835349.geojson
+++ b/data/101/835/349/101835349.geojson
@@ -86,6 +86,9 @@
         "qs_pg:id":1044039
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1f3b614cabeedabed9e16fab71e029e7",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
         }
     ],
     "wof:id":101835349,
-    "wof:lastmodified":1566647368,
+    "wof:lastmodified":1582318745,
     "wof:name":"Ka\u0161ina",
     "wof:parent_id":85684811,
     "wof:placetype":"locality",

--- a/data/101/835/353/101835353.geojson
+++ b/data/101/835/353/101835353.geojson
@@ -186,6 +186,9 @@
         "wd:id":"Q266168"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6361fb7e95d95322d39e47c445115ea8",
     "wof:hierarchy":[
         {
@@ -196,7 +199,7 @@
         }
     ],
     "wof:id":101835353,
-    "wof:lastmodified":1566647364,
+    "wof:lastmodified":1582318744,
     "wof:name":"Virovitica",
     "wof:parent_id":85684793,
     "wof:placetype":"locality",

--- a/data/101/835/355/101835355.geojson
+++ b/data/101/835/355/101835355.geojson
@@ -122,6 +122,9 @@
         "wk:page":"Suhopolje"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1f4401dd46e5a0835514f1379f1c2fb7",
     "wof:hierarchy":[
         {
@@ -132,7 +135,7 @@
         }
     ],
     "wof:id":101835355,
-    "wof:lastmodified":1566647365,
+    "wof:lastmodified":1582318744,
     "wof:name":"Suhopolje",
     "wof:parent_id":85684793,
     "wof:placetype":"locality",

--- a/data/101/835/357/101835357.geojson
+++ b/data/101/835/357/101835357.geojson
@@ -173,6 +173,9 @@
         "wk:page":"Zapre\u0161i\u0107"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"cd0ea9410e64b4880486641bd33c9b3e",
     "wof:hierarchy":[
         {
@@ -186,7 +189,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647370,
+    "wof:lastmodified":1582318745,
     "wof:name":"Zapre\u0161i\u0107",
     "wof:parent_id":85684765,
     "wof:placetype":"locality",

--- a/data/101/835/363/101835363.geojson
+++ b/data/101/835/363/101835363.geojson
@@ -93,6 +93,9 @@
         "wk:page":"Novoselec"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5631dd8c7a979d148106e23572d1b7a5",
     "wof:hierarchy":[
         {
@@ -103,7 +106,7 @@
         }
     ],
     "wof:id":101835363,
-    "wof:lastmodified":1566647365,
+    "wof:lastmodified":1582318744,
     "wof:name":"Novoselec",
     "wof:parent_id":85684765,
     "wof:placetype":"locality",

--- a/data/101/835/365/101835365.geojson
+++ b/data/101/835/365/101835365.geojson
@@ -123,6 +123,9 @@
         "wk:page":"Kri\u017e"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"21acdccb15fbec7abf9b5536fc8aebc8",
     "wof:hierarchy":[
         {
@@ -136,7 +139,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647364,
+    "wof:lastmodified":1582318744,
     "wof:name":"Kri\u017e",
     "wof:parent_id":85684765,
     "wof:placetype":"locality",

--- a/data/101/835/377/101835377.geojson
+++ b/data/101/835/377/101835377.geojson
@@ -202,6 +202,9 @@
         "wd:id":"Q331141"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9567532a9f16947677d042bcda8d290a",
     "wof:hierarchy":[
         {
@@ -215,7 +218,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647368,
+    "wof:lastmodified":1582318745,
     "wof:name":"Velika Gorica",
     "wof:parent_id":85684765,
     "wof:placetype":"locality",

--- a/data/101/835/379/101835379.geojson
+++ b/data/101/835/379/101835379.geojson
@@ -89,6 +89,9 @@
         "wk:page":"Gradi\u0107i"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"fac6ca8fe7f99df811736303724d680a",
     "wof:hierarchy":[
         {
@@ -99,7 +102,7 @@
         }
     ],
     "wof:id":101835379,
-    "wof:lastmodified":1566647367,
+    "wof:lastmodified":1582318744,
     "wof:name":"Gradi\u0107i",
     "wof:parent_id":85684765,
     "wof:placetype":"locality",

--- a/data/101/835/381/101835381.geojson
+++ b/data/101/835/381/101835381.geojson
@@ -91,6 +91,9 @@
         "qs_pg:id":581588
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8eabac8addbcd11a3d041939f5c6750d",
     "wof:hierarchy":[
         {
@@ -101,7 +104,7 @@
         }
     ],
     "wof:id":101835381,
-    "wof:lastmodified":1566647374,
+    "wof:lastmodified":1582318745,
     "wof:name":"Strmec",
     "wof:parent_id":85684765,
     "wof:placetype":"locality",

--- a/data/101/835/385/101835385.geojson
+++ b/data/101/835/385/101835385.geojson
@@ -89,6 +89,9 @@
         "wk:page":"Bestovje"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"af8792d55e6d65d6296058c378388a00",
     "wof:hierarchy":[
         {
@@ -99,7 +102,7 @@
         }
     ],
     "wof:id":101835385,
-    "wof:lastmodified":1566647368,
+    "wof:lastmodified":1582318745,
     "wof:name":"Bestovje",
     "wof:parent_id":85684765,
     "wof:placetype":"locality",

--- a/data/101/835/391/101835391.geojson
+++ b/data/101/835/391/101835391.geojson
@@ -95,6 +95,9 @@
         "qs_pg:id":147314
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"62bf2b04731ee6a8b47c5974e956fcf4",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
         }
     ],
     "wof:id":101835391,
-    "wof:lastmodified":1566647364,
+    "wof:lastmodified":1582318744,
     "wof:name":"Brezje",
     "wof:parent_id":85684765,
     "wof:placetype":"locality",

--- a/data/101/835/395/101835395.geojson
+++ b/data/101/835/395/101835395.geojson
@@ -158,6 +158,9 @@
         "wk:page":"Beli\u0161\u0107e"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"34fef295da7daf9f071095cdd0cdba33",
     "wof:hierarchy":[
         {
@@ -171,7 +174,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647369,
+    "wof:lastmodified":1582318745,
     "wof:name":"Beli\u0161\u0107e",
     "wof:parent_id":85684805,
     "wof:placetype":"locality",

--- a/data/101/835/397/101835397.geojson
+++ b/data/101/835/397/101835397.geojson
@@ -120,6 +120,9 @@
         "wk:page":"\u010cepin"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"74909c200a91f01c52d6704b8d6666d4",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647365,
+    "wof:lastmodified":1582318744,
     "wof:name":"\u010cepin",
     "wof:parent_id":85684805,
     "wof:placetype":"locality",

--- a/data/101/835/399/101835399.geojson
+++ b/data/101/835/399/101835399.geojson
@@ -76,6 +76,9 @@
         "wd:id":"Q12756427"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"96305e76ef5b50b0e2ba35141f71c36f",
     "wof:hierarchy":[
         {
@@ -86,7 +89,7 @@
         }
     ],
     "wof:id":101835399,
-    "wof:lastmodified":1566647365,
+    "wof:lastmodified":1582318744,
     "wof:name":"Ov\u010dara",
     "wof:parent_id":85684805,
     "wof:placetype":"locality",

--- a/data/101/835/403/101835403.geojson
+++ b/data/101/835/403/101835403.geojson
@@ -162,6 +162,9 @@
         "wd:id":"Q397652"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7c9bbb1d76af0a3cfa7dde26581dd197",
     "wof:hierarchy":[
         {
@@ -172,7 +175,7 @@
         }
     ],
     "wof:id":101835403,
-    "wof:lastmodified":1566647372,
+    "wof:lastmodified":1582318745,
     "wof:name":"Na\u0161ice",
     "wof:parent_id":85684805,
     "wof:placetype":"locality",

--- a/data/101/835/407/101835407.geojson
+++ b/data/101/835/407/101835407.geojson
@@ -89,6 +89,9 @@
         "wk:page":"Bistrinci"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d21c23eb86fbbb7f84a3345158d15a61",
     "wof:hierarchy":[
         {
@@ -99,7 +102,7 @@
         }
     ],
     "wof:id":101835407,
-    "wof:lastmodified":1566647367,
+    "wof:lastmodified":1582318744,
     "wof:name":"Bistrinci",
     "wof:parent_id":85684805,
     "wof:placetype":"locality",

--- a/data/101/835/411/101835411.geojson
+++ b/data/101/835/411/101835411.geojson
@@ -92,6 +92,9 @@
         "wk:page":"\u017ddralovi"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"13158ab759949cc015ef5328ccd93ade",
     "wof:hierarchy":[
         {
@@ -102,7 +105,7 @@
         }
     ],
     "wof:id":101835411,
-    "wof:lastmodified":1566647371,
+    "wof:lastmodified":1582318745,
     "wof:name":"\u017ddralovi",
     "wof:parent_id":85684753,
     "wof:placetype":"locality",

--- a/data/101/835/415/101835415.geojson
+++ b/data/101/835/415/101835415.geojson
@@ -95,6 +95,9 @@
         "wk:page":"Gudovac"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"da1c0d31a3d51c8860d5b5145930a11c",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
         }
     ],
     "wof:id":101835415,
-    "wof:lastmodified":1566647366,
+    "wof:lastmodified":1582318744,
     "wof:name":"Gudovac",
     "wof:parent_id":85684753,
     "wof:placetype":"locality",

--- a/data/101/835/417/101835417.geojson
+++ b/data/101/835/417/101835417.geojson
@@ -229,6 +229,9 @@
         "wk:page":"Bjelovar"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ad28d19c4163c6b5138390009843721f",
     "wof:hierarchy":[
         {
@@ -242,7 +245,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647371,
+    "wof:lastmodified":1582318745,
     "wof:name":"Bjelovar",
     "wof:parent_id":85684753,
     "wof:placetype":"locality",

--- a/data/101/835/425/101835425.geojson
+++ b/data/101/835/425/101835425.geojson
@@ -132,6 +132,9 @@
         "wk:page":"Oroslavje"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"362d8b44d24e52b6a048aac499ba17e9",
     "wof:hierarchy":[
         {
@@ -145,7 +148,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647366,
+    "wof:lastmodified":1582318744,
     "wof:name":"Oroslavje",
     "wof:parent_id":85684813,
     "wof:placetype":"locality",

--- a/data/101/836/405/101836405.geojson
+++ b/data/101/836/405/101836405.geojson
@@ -215,6 +215,9 @@
         "wd:id":"Q189161"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"17bbf2d7f057b5695083bc97fb680654",
     "wof:hierarchy":[
         {
@@ -228,7 +231,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647421,
+    "wof:lastmodified":1582318753,
     "wof:name":"Trogir",
     "wof:parent_id":85684781,
     "wof:placetype":"locality",

--- a/data/101/836/409/101836409.geojson
+++ b/data/101/836/409/101836409.geojson
@@ -76,6 +76,9 @@
         "wd:id":"Q12641904"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6a8e761c83435accc84ca10c5c299da0",
     "wof:hierarchy":[
         {
@@ -86,7 +89,7 @@
         }
     ],
     "wof:id":101836409,
-    "wof:lastmodified":1566647419,
+    "wof:lastmodified":1582318752,
     "wof:name":"Seget Vranjica",
     "wof:parent_id":85684781,
     "wof:placetype":"locality",

--- a/data/101/836/411/101836411.geojson
+++ b/data/101/836/411/101836411.geojson
@@ -207,6 +207,9 @@
         "wd:id":"Q189161"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"43e564c0c897bc7a0b2e5c560da01cda",
     "wof:hierarchy":[
         {
@@ -217,7 +220,7 @@
         }
     ],
     "wof:id":101836411,
-    "wof:lastmodified":1566647420,
+    "wof:lastmodified":1582318752,
     "wof:name":"Seget Donji",
     "wof:parent_id":85684781,
     "wof:placetype":"locality",

--- a/data/101/836/415/101836415.geojson
+++ b/data/101/836/415/101836415.geojson
@@ -103,6 +103,9 @@
         "wd:id":"Q6458033"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"29e315cec6d0c67d44d725b1141ac7a3",
     "wof:hierarchy":[
         {
@@ -113,7 +116,7 @@
         }
     ],
     "wof:id":101836415,
-    "wof:lastmodified":1566647418,
+    "wof:lastmodified":1582318752,
     "wof:name":"Jesenice",
     "wof:parent_id":85684781,
     "wof:placetype":"locality",

--- a/data/101/836/417/101836417.geojson
+++ b/data/101/836/417/101836417.geojson
@@ -118,6 +118,9 @@
         "wk:page":"Dugi Rat"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0d963a98dc0fdacb614fb1968cf4cb6a",
     "wof:hierarchy":[
         {
@@ -131,7 +134,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647419,
+    "wof:lastmodified":1582318752,
     "wof:name":"Dugi Rat",
     "wof:parent_id":85684781,
     "wof:placetype":"locality",

--- a/data/101/836/421/101836421.geojson
+++ b/data/101/836/421/101836421.geojson
@@ -170,6 +170,9 @@
         "wk:page":"Imotski"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e003ea17f439df45194e18d8afb40272",
     "wof:hierarchy":[
         {
@@ -183,7 +186,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647419,
+    "wof:lastmodified":1582318752,
     "wof:name":"Imotski",
     "wof:parent_id":85684781,
     "wof:placetype":"locality",

--- a/data/101/836/423/101836423.geojson
+++ b/data/101/836/423/101836423.geojson
@@ -174,6 +174,9 @@
         "wk:page":"Sinj"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"37b7f3aa3224c92506a94f4fa919e440",
     "wof:hierarchy":[
         {
@@ -187,7 +190,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647418,
+    "wof:lastmodified":1582318752,
     "wof:name":"Sinj",
     "wof:parent_id":85684781,
     "wof:placetype":"locality",

--- a/data/101/836/427/101836427.geojson
+++ b/data/101/836/427/101836427.geojson
@@ -340,6 +340,9 @@
         "wd:id":"Q3549"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"eec40489040b73b9f64f7ebc3052d660",
     "wof:hierarchy":[
         {
@@ -350,7 +353,7 @@
         }
     ],
     "wof:id":101836427,
-    "wof:lastmodified":1566647420,
+    "wof:lastmodified":1582318752,
     "wof:name":"\u0160ibenik",
     "wof:parent_id":85684755,
     "wof:placetype":"locality",

--- a/data/101/836/429/101836429.geojson
+++ b/data/101/836/429/101836429.geojson
@@ -102,6 +102,9 @@
         "wk:page":"Bilice, \u0160ibenik-Knin County"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c0288e404d4c9be33287b8b35d686bcb",
     "wof:hierarchy":[
         {
@@ -112,7 +115,7 @@
         }
     ],
     "wof:id":101836429,
-    "wof:lastmodified":1566647420,
+    "wof:lastmodified":1582318752,
     "wof:name":"Bilice",
     "wof:parent_id":85684755,
     "wof:placetype":"locality",

--- a/data/101/836/433/101836433.geojson
+++ b/data/101/836/433/101836433.geojson
@@ -66,6 +66,9 @@
         "qs_pg:id":147101
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"cadc7c3ccfdd2d17f2e668cb32fb1b09",
     "wof:hierarchy":[
         {
@@ -76,7 +79,7 @@
         }
     ],
     "wof:id":101836433,
-    "wof:lastmodified":1566647421,
+    "wof:lastmodified":1582318753,
     "wof:name":"Turanj",
     "wof:parent_id":85684807,
     "wof:placetype":"locality",

--- a/data/101/836/435/101836435.geojson
+++ b/data/101/836/435/101836435.geojson
@@ -116,6 +116,9 @@
         "wk:page":"Sveti Filip i Jakov"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c13dbd357a128c2b8b80350b6b529528",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":101836435,
-    "wof:lastmodified":1566647421,
+    "wof:lastmodified":1582318753,
     "wof:name":"Sveti Filip i Jakov",
     "wof:parent_id":85684807,
     "wof:placetype":"locality",

--- a/data/101/836/439/101836439.geojson
+++ b/data/101/836/439/101836439.geojson
@@ -92,6 +92,9 @@
         "wk:page":"Banjol"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"80a89faf34bfa0d0e879e23e673438f1",
     "wof:hierarchy":[
         {
@@ -102,7 +105,7 @@
         }
     ],
     "wof:id":101836439,
-    "wof:lastmodified":1566647418,
+    "wof:lastmodified":1582318752,
     "wof:name":"Banjol",
     "wof:parent_id":85684789,
     "wof:placetype":"locality",

--- a/data/101/836/441/101836441.geojson
+++ b/data/101/836/441/101836441.geojson
@@ -96,6 +96,9 @@
         "wk:page":"Barbat, Croatia"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9d94564f37389812b835ca1e5f1cc0b5",
     "wof:hierarchy":[
         {
@@ -106,7 +109,7 @@
         }
     ],
     "wof:id":101836441,
-    "wof:lastmodified":1566647417,
+    "wof:lastmodified":1582318752,
     "wof:name":"Barbat na Rabu",
     "wof:parent_id":85684789,
     "wof:placetype":"locality",

--- a/data/101/836/443/101836443.geojson
+++ b/data/101/836/443/101836443.geojson
@@ -178,6 +178,9 @@
         "wk:page":"Labin"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"21d37db96d87ab9f765ba3ebda1606e7",
     "wof:hierarchy":[
         {
@@ -191,7 +194,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647420,
+    "wof:lastmodified":1582318752,
     "wof:name":"Labin",
     "wof:parent_id":85684829,
     "wof:placetype":"locality",

--- a/data/101/836/445/101836445.geojson
+++ b/data/101/836/445/101836445.geojson
@@ -91,6 +91,9 @@
         "wd:id":"Q2150596"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"668bfaaf047c22a31b09cbc67d16aa92",
     "wof:hierarchy":[
         {
@@ -101,7 +104,7 @@
         }
     ],
     "wof:id":101836445,
-    "wof:lastmodified":1566647420,
+    "wof:lastmodified":1582318753,
     "wof:name":"Vine\u017e",
     "wof:parent_id":85684829,
     "wof:placetype":"locality",

--- a/data/101/836/453/101836453.geojson
+++ b/data/101/836/453/101836453.geojson
@@ -104,6 +104,9 @@
         "wk:page":"Selce, Croatia"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"42c1be790eccd8a392bf93a30e9aebee",
     "wof:hierarchy":[
         {
@@ -114,7 +117,7 @@
         }
     ],
     "wof:id":101836453,
-    "wof:lastmodified":1566647419,
+    "wof:lastmodified":1582318752,
     "wof:name":"Selce",
     "wof:parent_id":85684789,
     "wof:placetype":"locality",

--- a/data/101/836/455/101836455.geojson
+++ b/data/101/836/455/101836455.geojson
@@ -317,6 +317,9 @@
         "wk:page":"Crikvenica"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0130a1cff55b3cb43bc22da417e52eef",
     "wof:hierarchy":[
         {
@@ -330,7 +333,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647419,
+    "wof:lastmodified":1582318752,
     "wof:name":"Crikvenica",
     "wof:parent_id":85684789,
     "wof:placetype":"locality",

--- a/data/101/836/457/101836457.geojson
+++ b/data/101/836/457/101836457.geojson
@@ -96,6 +96,9 @@
         "wk:page":"Dramalj"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"dfd5e04e2c1b65e9da05e3f9907bbbd0",
     "wof:hierarchy":[
         {
@@ -106,7 +109,7 @@
         }
     ],
     "wof:id":101836457,
-    "wof:lastmodified":1566647421,
+    "wof:lastmodified":1582318753,
     "wof:name":"Dramalj",
     "wof:parent_id":85684789,
     "wof:placetype":"locality",

--- a/data/101/844/743/101844743.geojson
+++ b/data/101/844/743/101844743.geojson
@@ -56,6 +56,9 @@
         "qs_pg:id":147099
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"19fb5733a64248bd2fff8f5a9fe1a964",
     "wof:hierarchy":[
         {
@@ -66,7 +69,7 @@
         }
     ],
     "wof:id":101844743,
-    "wof:lastmodified":1566647358,
+    "wof:lastmodified":1582318743,
     "wof:name":"Turjaci",
     "wof:parent_id":85684781,
     "wof:placetype":"locality",

--- a/data/101/844/745/101844745.geojson
+++ b/data/101/844/745/101844745.geojson
@@ -86,6 +86,9 @@
         "wk:page":"Srinjine"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5dc2e14e9a22152663fdd69e607c1b1e",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
         }
     ],
     "wof:id":101844745,
-    "wof:lastmodified":1566647359,
+    "wof:lastmodified":1582318743,
     "wof:name":"Srinjine",
     "wof:parent_id":85684781,
     "wof:placetype":"locality",

--- a/data/101/844/749/101844749.geojson
+++ b/data/101/844/749/101844749.geojson
@@ -89,6 +89,9 @@
         "wk:page":"\u017drnovnica"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3545532ed24060a481e2393423fa2e03",
     "wof:hierarchy":[
         {
@@ -99,7 +102,7 @@
         }
     ],
     "wof:id":101844749,
-    "wof:lastmodified":1566647355,
+    "wof:lastmodified":1582318742,
     "wof:name":"\u017drnovnica",
     "wof:parent_id":85684781,
     "wof:placetype":"locality",

--- a/data/101/844/751/101844751.geojson
+++ b/data/101/844/751/101844751.geojson
@@ -113,6 +113,9 @@
         "wk:page":"Kali, Croatia"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2e30f176d0101a0025e5ec96cc18e3a1",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
         }
     ],
     "wof:id":101844751,
-    "wof:lastmodified":1566647356,
+    "wof:lastmodified":1582318742,
     "wof:name":"Kali",
     "wof:parent_id":85684807,
     "wof:placetype":"locality",

--- a/data/101/844/753/101844753.geojson
+++ b/data/101/844/753/101844753.geojson
@@ -110,6 +110,9 @@
         "wk:page":"Kistanje"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d69d08053c908c1480a4a906238413dd",
     "wof:hierarchy":[
         {
@@ -120,7 +123,7 @@
         }
     ],
     "wof:id":101844753,
-    "wof:lastmodified":1566647354,
+    "wof:lastmodified":1582318742,
     "wof:name":"Kistanje",
     "wof:parent_id":85684755,
     "wof:placetype":"locality",

--- a/data/101/844/755/101844755.geojson
+++ b/data/101/844/755/101844755.geojson
@@ -107,6 +107,9 @@
         "wk:page":"Pola\u010da"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"17dca95d339f4d23d9751f96435f53ce",
     "wof:hierarchy":[
         {
@@ -117,7 +120,7 @@
         }
     ],
     "wof:id":101844755,
-    "wof:lastmodified":1566647354,
+    "wof:lastmodified":1582318742,
     "wof:name":"Pola\u010da",
     "wof:parent_id":85684807,
     "wof:placetype":"locality",

--- a/data/101/844/757/101844757.geojson
+++ b/data/101/844/757/101844757.geojson
@@ -125,6 +125,9 @@
         "wk:page":"Gra\u010dac"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"76ca85bdc91636a31340b7fae34e18f1",
     "wof:hierarchy":[
         {
@@ -135,7 +138,7 @@
         }
     ],
     "wof:id":101844757,
-    "wof:lastmodified":1566647357,
+    "wof:lastmodified":1582318742,
     "wof:name":"Gra\u010dac",
     "wof:parent_id":85684807,
     "wof:placetype":"locality",

--- a/data/101/844/759/101844759.geojson
+++ b/data/101/844/759/101844759.geojson
@@ -108,6 +108,9 @@
         "wk:page":"Galovac, Zadar County"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"640496e8a87f0e92cd98d67fed96f04f",
     "wof:hierarchy":[
         {
@@ -118,7 +121,7 @@
         }
     ],
     "wof:id":101844759,
-    "wof:lastmodified":1566647357,
+    "wof:lastmodified":1582318743,
     "wof:name":"Galovac",
     "wof:parent_id":85684807,
     "wof:placetype":"locality",

--- a/data/101/844/761/101844761.geojson
+++ b/data/101/844/761/101844761.geojson
@@ -92,6 +92,9 @@
         "wk:page":"Pridraga"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"96c2c901b6fcea5f5d06b312b2d9bff8",
     "wof:hierarchy":[
         {
@@ -102,7 +105,7 @@
         }
     ],
     "wof:id":101844761,
-    "wof:lastmodified":1566647357,
+    "wof:lastmodified":1582318742,
     "wof:name":"Pridraga",
     "wof:parent_id":85684807,
     "wof:placetype":"locality",

--- a/data/101/844/763/101844763.geojson
+++ b/data/101/844/763/101844763.geojson
@@ -304,6 +304,9 @@
         "wk:page":"Novalja"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"145afa60f3e529237039d43ed1f77b93",
     "wof:hierarchy":[
         {
@@ -317,7 +320,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647353,
+    "wof:lastmodified":1582318742,
     "wof:name":"Novalja",
     "wof:parent_id":85684785,
     "wof:placetype":"locality",

--- a/data/101/844/767/101844767.geojson
+++ b/data/101/844/767/101844767.geojson
@@ -119,6 +119,9 @@
         "wk:page":"Lopar, Croatia"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"55f2caf7ade4e5be14be646f6951ee0d",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
         }
     ],
     "wof:id":101844767,
-    "wof:lastmodified":1566647356,
+    "wof:lastmodified":1582318742,
     "wof:name":"Lopar",
     "wof:parent_id":85684789,
     "wof:placetype":"locality",

--- a/data/101/844/769/101844769.geojson
+++ b/data/101/844/769/101844769.geojson
@@ -104,6 +104,9 @@
         "wk:page":"Supetarska Draga"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2b6e234ec2b66461d09387753e4b5299",
     "wof:hierarchy":[
         {
@@ -114,7 +117,7 @@
         }
     ],
     "wof:id":101844769,
-    "wof:lastmodified":1566647356,
+    "wof:lastmodified":1582318742,
     "wof:name":"Supetarska Draga",
     "wof:parent_id":85684789,
     "wof:placetype":"locality",

--- a/data/101/844/773/101844773.geojson
+++ b/data/101/844/773/101844773.geojson
@@ -86,6 +86,9 @@
         "wk:page":"Slobodnica"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ae488e2f425e224d18fe73c1b8194a87",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
         }
     ],
     "wof:id":101844773,
-    "wof:lastmodified":1566647359,
+    "wof:lastmodified":1582318743,
     "wof:name":"Slobodnica",
     "wof:parent_id":85684749,
     "wof:placetype":"locality",

--- a/data/101/844/777/101844777.geojson
+++ b/data/101/844/777/101844777.geojson
@@ -114,6 +114,9 @@
         "wk:page":"Velika, Croatia"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f43bd62a3c245139c807563b1063daa2",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647355,
+    "wof:lastmodified":1582318742,
     "wof:name":"Velika",
     "wof:parent_id":85684763,
     "wof:placetype":"locality",

--- a/data/101/844/779/101844779.geojson
+++ b/data/101/844/779/101844779.geojson
@@ -95,6 +95,9 @@
         "wk:page":"Vetovo, Croatia"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1f1ec9df26c8ea909d3562f33a518cd0",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
         }
     ],
     "wof:id":101844779,
-    "wof:lastmodified":1566647356,
+    "wof:lastmodified":1582318742,
     "wof:name":"Vetovo",
     "wof:parent_id":85684763,
     "wof:placetype":"locality",

--- a/data/101/844/781/101844781.geojson
+++ b/data/101/844/781/101844781.geojson
@@ -113,6 +113,9 @@
         "wd:id":"Q1272324"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"892fbf1983daa658e54b9f5bc13aa781",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647358,
+    "wof:lastmodified":1582318743,
     "wof:name":"Jak\u0161i\u0107",
     "wof:parent_id":85684763,
     "wof:placetype":"locality",

--- a/data/101/844/785/101844785.geojson
+++ b/data/101/844/785/101844785.geojson
@@ -114,6 +114,9 @@
         "wk:page":"Lovas, Croatia"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a2106b4b58e776eb400d1a1bdcd1e128",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647355,
+    "wof:lastmodified":1582318742,
     "wof:name":"Lovas",
     "wof:parent_id":85684733,
     "wof:placetype":"locality",

--- a/data/101/844/787/101844787.geojson
+++ b/data/101/844/787/101844787.geojson
@@ -120,6 +120,9 @@
         "wk:page":"Dvor, Croatia"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e259d730e9e5b8d7b37747a6fd167f62",
     "wof:hierarchy":[
         {
@@ -139,7 +142,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647359,
+    "wof:lastmodified":1582318743,
     "wof:name":"Dvor",
     "wof:parent_id":85684769,
     "wof:placetype":"locality",

--- a/data/101/844/789/101844789.geojson
+++ b/data/101/844/789/101844789.geojson
@@ -132,6 +132,9 @@
         "wk:page":"Gvozd"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9daa2b6dca09e85b5dd380e92909b82d",
     "wof:hierarchy":[
         {
@@ -145,7 +148,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647359,
+    "wof:lastmodified":1582318743,
     "wof:name":"Gvozd",
     "wof:parent_id":85684769,
     "wof:placetype":"locality",

--- a/data/101/844/791/101844791.geojson
+++ b/data/101/844/791/101844791.geojson
@@ -91,6 +91,9 @@
         "wd:id":"Q3442570"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f67bbc20211e46a99763c2f8882b2f9b",
     "wof:hierarchy":[
         {
@@ -101,7 +104,7 @@
         }
     ],
     "wof:id":101844791,
-    "wof:lastmodified":1566647354,
+    "wof:lastmodified":1582318742,
     "wof:name":"Voloder",
     "wof:parent_id":85684769,
     "wof:placetype":"locality",

--- a/data/101/844/797/101844797.geojson
+++ b/data/101/844/797/101844797.geojson
@@ -117,6 +117,9 @@
         "wk:page":"Jakovlje"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"da7058203a93c008cf3c33cca2c85e3e",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647353,
+    "wof:lastmodified":1582318742,
     "wof:name":"Jakovlje",
     "wof:parent_id":85684765,
     "wof:placetype":"locality",

--- a/data/101/844/799/101844799.geojson
+++ b/data/101/844/799/101844799.geojson
@@ -86,6 +86,9 @@
         "wk:page":"Kerestinec"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2909584bebadf538e572edc10da88c6a",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
         }
     ],
     "wof:id":101844799,
-    "wof:lastmodified":1566647354,
+    "wof:lastmodified":1582318742,
     "wof:name":"Kerestinec",
     "wof:parent_id":85684765,
     "wof:placetype":"locality",

--- a/data/101/844/805/101844805.geojson
+++ b/data/101/844/805/101844805.geojson
@@ -120,6 +120,9 @@
         "wk:page":"Jagodnjak"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"afb0933ff44ac5872e831b64fe06ea48",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647355,
+    "wof:lastmodified":1582318742,
     "wof:name":"Jagodnjak",
     "wof:parent_id":85684805,
     "wof:placetype":"locality",

--- a/data/101/844/809/101844809.geojson
+++ b/data/101/844/809/101844809.geojson
@@ -76,6 +76,9 @@
         "wd:id":"Q772586"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e14b87d450e96b01b46c4421ce21d262",
     "wof:hierarchy":[
         {
@@ -86,7 +89,7 @@
         }
     ],
     "wof:id":101844809,
-    "wof:lastmodified":1566647358,
+    "wof:lastmodified":1582318743,
     "wof:name":"Brijest",
     "wof:parent_id":85684805,
     "wof:placetype":"locality",

--- a/data/101/844/815/101844815.geojson
+++ b/data/101/844/815/101844815.geojson
@@ -92,6 +92,9 @@
         "wk:page":"Ivanovec"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c9b71def020ffff93136faf3a19b42a3",
     "wof:hierarchy":[
         {
@@ -102,7 +105,7 @@
         }
     ],
     "wof:id":101844815,
-    "wof:lastmodified":1566647357,
+    "wof:lastmodified":1582318743,
     "wof:name":"Ivanovec",
     "wof:parent_id":85684823,
     "wof:placetype":"locality",

--- a/data/101/846/135/101846135.geojson
+++ b/data/101/846/135/101846135.geojson
@@ -146,6 +146,9 @@
         "wk:page":"Cavtat"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1b50d3af2bc29d94c17cec9eee5cd77b",
     "wof:hierarchy":[
         {
@@ -156,7 +159,7 @@
         }
     ],
     "wof:id":101846135,
-    "wof:lastmodified":1566647416,
+    "wof:lastmodified":1582318752,
     "wof:name":"Cavtat",
     "wof:parent_id":85684775,
     "wof:placetype":"locality",

--- a/data/101/846/137/101846137.geojson
+++ b/data/101/846/137/101846137.geojson
@@ -194,6 +194,9 @@
         "wk:page":"Supetar"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e01fa43e39f76942d82d7bb910c62f8f",
     "wof:hierarchy":[
         {
@@ -207,7 +210,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647417,
+    "wof:lastmodified":1582318752,
     "wof:name":"Supetar",
     "wof:parent_id":85684781,
     "wof:placetype":"locality",

--- a/data/101/846/139/101846139.geojson
+++ b/data/101/846/139/101846139.geojson
@@ -137,6 +137,9 @@
         "qs_pg:id":892237
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e95a823633e80fcb183074d7477560fd",
     "wof:hierarchy":[
         {
@@ -147,7 +150,7 @@
         }
     ],
     "wof:id":101846139,
-    "wof:lastmodified":1566647416,
+    "wof:lastmodified":1582318752,
     "wof:name":"Ba\u0161ka Voda",
     "wof:parent_id":85684781,
     "wof:placetype":"locality",

--- a/data/101/846/141/101846141.geojson
+++ b/data/101/846/141/101846141.geojson
@@ -145,6 +145,9 @@
         "wd:id":"Q398436"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"86fec68adfd852ffde52d841fd7d9f29",
     "wof:hierarchy":[
         {
@@ -158,7 +161,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647417,
+    "wof:lastmodified":1582318752,
     "wof:name":"Vrgorac",
     "wof:parent_id":85684781,
     "wof:placetype":"locality",

--- a/data/101/857/801/101857801.geojson
+++ b/data/101/857/801/101857801.geojson
@@ -97,6 +97,10 @@
         "wk:page":"Komin, Dubrovnik-Neretva County"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"feabce157ade8da004dc36f418d85cb4",
     "wof:hierarchy":[
         {
@@ -107,7 +111,7 @@
         }
     ],
     "wof:id":101857801,
-    "wof:lastmodified":1566647363,
+    "wof:lastmodified":1582318744,
     "wof:name":"Komin",
     "wof:parent_id":85684775,
     "wof:placetype":"locality",

--- a/data/101/857/803/101857803.geojson
+++ b/data/101/857/803/101857803.geojson
@@ -122,6 +122,9 @@
         "wk:page":"Pu\u010di\u0161\u0107a"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"25dc61d9c1267285f9c5ee26aa2dd476",
     "wof:hierarchy":[
         {
@@ -132,7 +135,7 @@
         }
     ],
     "wof:id":101857803,
-    "wof:lastmodified":1566647361,
+    "wof:lastmodified":1582318743,
     "wof:name":"Pu\u010di\u0161\u0107a",
     "wof:parent_id":85684781,
     "wof:placetype":"locality",

--- a/data/101/857/805/101857805.geojson
+++ b/data/101/857/805/101857805.geojson
@@ -88,6 +88,10 @@
         "wk:page":"Ko\u0161ute"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6c29451be2f39285a3e81e7bea666fb3",
     "wof:hierarchy":[
         {
@@ -98,7 +102,7 @@
         }
     ],
     "wof:id":101857805,
-    "wof:lastmodified":1566647362,
+    "wof:lastmodified":1582318743,
     "wof:name":"Ko\u0161ute",
     "wof:parent_id":85684781,
     "wof:placetype":"locality",

--- a/data/101/857/807/101857807.geojson
+++ b/data/101/857/807/101857807.geojson
@@ -52,6 +52,9 @@
         "qs_pg:id":4
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"74b4c1bad38fe09d62a894c3dfa55e45",
     "wof:hierarchy":[
         {
@@ -62,7 +65,7 @@
         }
     ],
     "wof:id":101857807,
-    "wof:lastmodified":1566647363,
+    "wof:lastmodified":1582318744,
     "wof:name":"Cista Velika",
     "wof:parent_id":85684781,
     "wof:placetype":"locality",

--- a/data/101/857/809/101857809.geojson
+++ b/data/101/857/809/101857809.geojson
@@ -49,6 +49,9 @@
         "qs_pg:id":7
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"15e81b92f19804f372e58a0a2da1cb1b",
     "wof:hierarchy":[
         {
@@ -59,7 +62,7 @@
         }
     ],
     "wof:id":101857809,
-    "wof:lastmodified":1566647363,
+    "wof:lastmodified":1582318744,
     "wof:name":"Gornji Vinjani",
     "wof:parent_id":85684781,
     "wof:placetype":"locality",

--- a/data/101/857/811/101857811.geojson
+++ b/data/101/857/811/101857811.geojson
@@ -84,6 +84,9 @@
         "wk:page":"Donji Vinjani"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"deda35a0954d033f0c0f42b91aeac09f",
     "wof:hierarchy":[
         {
@@ -94,7 +97,7 @@
         }
     ],
     "wof:id":101857811,
-    "wof:lastmodified":1566647360,
+    "wof:lastmodified":1582318743,
     "wof:name":"Donji Vinjani",
     "wof:parent_id":85684781,
     "wof:placetype":"locality",

--- a/data/101/857/813/101857813.geojson
+++ b/data/101/857/813/101857813.geojson
@@ -99,6 +99,9 @@
         "wd:id":"Q1277230"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d813bbbf984edd1a613785c7d12f4bd6",
     "wof:hierarchy":[
         {
@@ -109,7 +112,7 @@
         }
     ],
     "wof:id":101857813,
-    "wof:lastmodified":1566647362,
+    "wof:lastmodified":1582318743,
     "wof:name":"Postranje",
     "wof:parent_id":85684781,
     "wof:placetype":"locality",

--- a/data/101/857/817/101857817.geojson
+++ b/data/101/857/817/101857817.geojson
@@ -126,6 +126,10 @@
         "wk:page":"Hrvace"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d63c05684dccf81f92bc5938607b6f93",
     "wof:hierarchy":[
         {
@@ -139,7 +143,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647360,
+    "wof:lastmodified":1582318743,
     "wof:name":"Hrvace",
     "wof:parent_id":85684781,
     "wof:placetype":"locality",

--- a/data/101/857/819/101857819.geojson
+++ b/data/101/857/819/101857819.geojson
@@ -140,6 +140,10 @@
         "qs_pg:id":147279
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e6511487f85f3b88db394aadadf8f085",
     "wof:hierarchy":[
         {
@@ -150,7 +154,7 @@
         }
     ],
     "wof:id":101857819,
-    "wof:lastmodified":1566647360,
+    "wof:lastmodified":1582318743,
     "wof:name":"Gala",
     "wof:parent_id":85684781,
     "wof:placetype":"locality",

--- a/data/101/857/821/101857821.geojson
+++ b/data/101/857/821/101857821.geojson
@@ -128,6 +128,10 @@
         "wk:page":"Podstrana"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ec820caeff1a0913267fefa287053ded",
     "wof:hierarchy":[
         {
@@ -141,7 +145,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647360,
+    "wof:lastmodified":1582318743,
     "wof:name":"Podstrana",
     "wof:parent_id":85684781,
     "wof:placetype":"locality",

--- a/data/101/857/823/101857823.geojson
+++ b/data/101/857/823/101857823.geojson
@@ -237,6 +237,9 @@
         "wd:id":"Q3549"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2b946ed20cb18dc03eb4f518d9665e41",
     "wof:hierarchy":[
         {
@@ -247,7 +250,7 @@
         }
     ],
     "wof:id":101857823,
-    "wof:lastmodified":1566647362,
+    "wof:lastmodified":1582318743,
     "wof:name":"Dubrava kod \u0160ibenika",
     "wof:parent_id":85684755,
     "wof:placetype":"locality",

--- a/data/101/857/825/101857825.geojson
+++ b/data/101/857/825/101857825.geojson
@@ -110,6 +110,10 @@
         "wk:page":"Jasenice, Zadar County"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b26c43dd6a63d2e42ed45206c406eee1",
     "wof:hierarchy":[
         {
@@ -120,7 +124,7 @@
         }
     ],
     "wof:id":101857825,
-    "wof:lastmodified":1566647363,
+    "wof:lastmodified":1582318744,
     "wof:name":"Jasenice",
     "wof:parent_id":85684807,
     "wof:placetype":"locality",

--- a/data/101/857/827/101857827.geojson
+++ b/data/101/857/827/101857827.geojson
@@ -162,6 +162,9 @@
         "qs_pg:id":967078
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f95f4d880092a6a72c7b94bffdc2d410",
     "wof:hierarchy":[
         {
@@ -172,7 +175,7 @@
         }
     ],
     "wof:id":101857827,
-    "wof:lastmodified":1566647359,
+    "wof:lastmodified":1582318743,
     "wof:name":"Kru\u0161evo",
     "wof:parent_id":85684807,
     "wof:placetype":"locality",

--- a/data/101/857/829/101857829.geojson
+++ b/data/101/857/829/101857829.geojson
@@ -98,6 +98,10 @@
         "qs_pg:id":1044102
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"0a2403a97de0e5381a6cdb9470191dcb",
     "wof:hierarchy":[
         {
@@ -108,7 +112,7 @@
         }
     ],
     "wof:id":101857829,
-    "wof:lastmodified":1566647359,
+    "wof:lastmodified":1582318743,
     "wof:name":"Kampor",
     "wof:parent_id":85684789,
     "wof:placetype":"locality",

--- a/data/101/857/831/101857831.geojson
+++ b/data/101/857/831/101857831.geojson
@@ -88,6 +88,10 @@
         "wk:page":"Batrina"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"0dcf3b267a69d38ec6a9f3fff5fba983",
     "wof:hierarchy":[
         {
@@ -98,7 +102,7 @@
         }
     ],
     "wof:id":101857831,
-    "wof:lastmodified":1566647363,
+    "wof:lastmodified":1582318744,
     "wof:name":"Batrina",
     "wof:parent_id":85684749,
     "wof:placetype":"locality",

--- a/data/101/857/835/101857835.geojson
+++ b/data/101/857/835/101857835.geojson
@@ -120,6 +120,10 @@
         "wd:id":"Q258149"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"bd2e462f570f18e760a75118b9865b83",
     "wof:hierarchy":[
         {
@@ -130,7 +134,7 @@
         }
     ],
     "wof:id":101857835,
-    "wof:lastmodified":1566647361,
+    "wof:lastmodified":1582318743,
     "wof:name":"Vrbova",
     "wof:parent_id":85684749,
     "wof:placetype":"locality",

--- a/data/101/857/837/101857837.geojson
+++ b/data/101/857/837/101857837.geojson
@@ -84,6 +84,10 @@
         "wd:id":"Q5306189"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"f954b0ff2796fc5bdc93a5b4f252d934",
     "wof:hierarchy":[
         {
@@ -94,7 +98,7 @@
         }
     ],
     "wof:id":101857837,
-    "wof:lastmodified":1566647363,
+    "wof:lastmodified":1582318744,
     "wof:name":"Dra\u017eice",
     "wof:parent_id":85684789,
     "wof:placetype":"locality",

--- a/data/101/857/839/101857839.geojson
+++ b/data/101/857/839/101857839.geojson
@@ -166,6 +166,9 @@
         "wd:id":"Q398115"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f3d8ce9a3229710c17d00b87426792c6",
     "wof:hierarchy":[
         {
@@ -176,7 +179,7 @@
         }
     ],
     "wof:id":101857839,
-    "wof:lastmodified":1566647363,
+    "wof:lastmodified":1582318744,
     "wof:name":"Prekopakra",
     "wof:parent_id":85684763,
     "wof:placetype":"locality",

--- a/data/101/857/841/101857841.geojson
+++ b/data/101/857/841/101857841.geojson
@@ -79,6 +79,9 @@
         "wk:page":"Kupine\u010dki Kraljevec"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3b38fdb3e62d4a1a2f444cc77f0a1b1e",
     "wof:hierarchy":[
         {
@@ -89,7 +92,7 @@
         }
     ],
     "wof:id":101857841,
-    "wof:lastmodified":1566647362,
+    "wof:lastmodified":1582318743,
     "wof:name":"Kupine\u010dki Kraljevec",
     "wof:parent_id":85684811,
     "wof:placetype":"locality",

--- a/data/101/857/843/101857843.geojson
+++ b/data/101/857/843/101857843.geojson
@@ -87,6 +87,10 @@
         "wd:id":"Q3442392"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4bf4b43653711c5169fbd2c310b50453",
     "wof:hierarchy":[
         {
@@ -97,7 +101,7 @@
         }
     ],
     "wof:id":101857843,
-    "wof:lastmodified":1566647361,
+    "wof:lastmodified":1582318743,
     "wof:name":"Horvati",
     "wof:parent_id":85684811,
     "wof:placetype":"locality",

--- a/data/101/857/845/101857845.geojson
+++ b/data/101/857/845/101857845.geojson
@@ -124,6 +124,10 @@
         "wk:page":"Vo\u0107in"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"f2564413eaab9dbf8ef58bb8e13458fb",
     "wof:hierarchy":[
         {
@@ -134,7 +138,7 @@
         }
     ],
     "wof:id":101857845,
-    "wof:lastmodified":1566647360,
+    "wof:lastmodified":1582318743,
     "wof:name":"Vo\u0107in",
     "wof:parent_id":85684793,
     "wof:placetype":"locality",

--- a/data/101/857/847/101857847.geojson
+++ b/data/101/857/847/101857847.geojson
@@ -81,6 +81,9 @@
         "wd:id":"Q403246"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0eb01311e4e97663b45fea1ba7f25bd0",
     "wof:hierarchy":[
         {
@@ -91,7 +94,7 @@
         }
     ],
     "wof:id":101857847,
-    "wof:lastmodified":1566647362,
+    "wof:lastmodified":1582318743,
     "wof:name":"Milanovac",
     "wof:parent_id":85684793,
     "wof:placetype":"locality",

--- a/data/101/857/849/101857849.geojson
+++ b/data/101/857/849/101857849.geojson
@@ -82,6 +82,9 @@
         "wd:id":"Q2061992"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2b412feaa503e966fce1c3c83325847b",
     "wof:hierarchy":[
         {
@@ -92,7 +95,7 @@
         }
     ],
     "wof:id":101857849,
-    "wof:lastmodified":1566647362,
+    "wof:lastmodified":1582318743,
     "wof:name":"Veliko Polje",
     "wof:parent_id":85684793,
     "wof:placetype":"locality",

--- a/data/101/857/853/101857853.geojson
+++ b/data/101/857/853/101857853.geojson
@@ -111,6 +111,10 @@
         "wd:id":"Q4122037"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c8846458a8468931f52cf1ee68207b11",
     "wof:hierarchy":[
         {
@@ -121,7 +125,7 @@
         }
     ],
     "wof:id":101857853,
-    "wof:lastmodified":1566647363,
+    "wof:lastmodified":1582318744,
     "wof:name":"Rude",
     "wof:parent_id":85684765,
     "wof:placetype":"locality",

--- a/data/101/857/855/101857855.geojson
+++ b/data/101/857/855/101857855.geojson
@@ -91,6 +91,10 @@
         "wk:page":"Rakitje"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0241aa19f5e1111f8bf44c5d92ebb5ba",
     "wof:hierarchy":[
         {
@@ -101,7 +105,7 @@
         }
     ],
     "wof:id":101857855,
-    "wof:lastmodified":1566647363,
+    "wof:lastmodified":1582318744,
     "wof:name":"Rakitje",
     "wof:parent_id":85684765,
     "wof:placetype":"locality",

--- a/data/101/857/857/101857857.geojson
+++ b/data/101/857/857/101857857.geojson
@@ -92,6 +92,10 @@
         "wd:id":"Q6505214"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"e417fe26cce799b6b522f266c7d04cca",
     "wof:hierarchy":[
         {
@@ -102,7 +106,7 @@
         }
     ],
     "wof:id":101857857,
-    "wof:lastmodified":1566647361,
+    "wof:lastmodified":1582318743,
     "wof:name":"Martin",
     "wof:parent_id":85684805,
     "wof:placetype":"locality",

--- a/data/101/857/859/101857859.geojson
+++ b/data/101/857/859/101857859.geojson
@@ -94,6 +94,10 @@
         "wk:page":"Predavac"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9f28e243aae6f9d6917200039399c8b0",
     "wof:hierarchy":[
         {
@@ -104,7 +108,7 @@
         }
     ],
     "wof:id":101857859,
-    "wof:lastmodified":1566647361,
+    "wof:lastmodified":1582318743,
     "wof:name":"Predavac",
     "wof:parent_id":85684753,
     "wof:placetype":"locality",

--- a/data/101/857/861/101857861.geojson
+++ b/data/101/857/861/101857861.geojson
@@ -119,6 +119,10 @@
         "wk:page":"De\u017eanovac"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"2072d6d1259f787a76f42ad8e1b92aef",
     "wof:hierarchy":[
         {
@@ -132,7 +136,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647361,
+    "wof:lastmodified":1582318743,
     "wof:name":"De\u017eanovac",
     "wof:parent_id":85684753,
     "wof:placetype":"locality",

--- a/data/101/857/863/101857863.geojson
+++ b/data/101/857/863/101857863.geojson
@@ -108,6 +108,10 @@
         "wk:page":"Mihovljan, Krapina-Zagorje County"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"6c71c85a3e3677b3fc703d77d733d31d",
     "wof:hierarchy":[
         {
@@ -121,7 +125,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647363,
+    "wof:lastmodified":1582318744,
     "wof:name":"Mihovljan",
     "wof:parent_id":85684813,
     "wof:placetype":"locality",

--- a/data/101/857/865/101857865.geojson
+++ b/data/101/857/865/101857865.geojson
@@ -79,6 +79,9 @@
         "wd:id":"Q846195"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d4936b538eef5287907a1af3b57ef9c8",
     "wof:hierarchy":[
         {
@@ -89,7 +92,7 @@
         }
     ],
     "wof:id":101857865,
-    "wof:lastmodified":1566647363,
+    "wof:lastmodified":1582318744,
     "wof:name":"Donja \u0160emnica",
     "wof:parent_id":85684813,
     "wof:placetype":"locality",

--- a/data/101/857/867/101857867.geojson
+++ b/data/101/857/867/101857867.geojson
@@ -110,6 +110,10 @@
         "wk:page":"Radoboj"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e3ace85d255f049289b2674a27956735",
     "wof:hierarchy":[
         {
@@ -123,7 +127,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647361,
+    "wof:lastmodified":1582318743,
     "wof:name":"Radoboj",
     "wof:parent_id":85684813,
     "wof:placetype":"locality",

--- a/data/101/857/871/101857871.geojson
+++ b/data/101/857/871/101857871.geojson
@@ -104,6 +104,9 @@
         "wk:page":"Hum na Sutli"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"37b5e948fb790c7db675a89e685adb1c",
     "wof:hierarchy":[
         {
@@ -117,7 +120,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647362,
+    "wof:lastmodified":1582318743,
     "wof:name":"Hum na Sutli",
     "wof:parent_id":85684813,
     "wof:placetype":"locality",

--- a/data/101/857/873/101857873.geojson
+++ b/data/101/857/873/101857873.geojson
@@ -100,6 +100,9 @@
         "wk:page":"Novo Virje"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d2d15ad572087101f4bf64ac74608463",
     "wof:hierarchy":[
         {
@@ -110,7 +113,7 @@
         }
     ],
     "wof:id":101857873,
-    "wof:lastmodified":1566647360,
+    "wof:lastmodified":1582318743,
     "wof:name":"Novo Virje",
     "wof:parent_id":85684799,
     "wof:placetype":"locality",

--- a/data/101/857/875/101857875.geojson
+++ b/data/101/857/875/101857875.geojson
@@ -112,6 +112,9 @@
         "wk:page":"Klenovnik, Croatia"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9f4c6bab37d8e175a24f36e70973d2fe",
     "wof:hierarchy":[
         {
@@ -125,7 +128,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647360,
+    "wof:lastmodified":1582318743,
     "wof:name":"Klenovnik",
     "wof:parent_id":85684835,
     "wof:placetype":"locality",

--- a/data/101/857/877/101857877.geojson
+++ b/data/101/857/877/101857877.geojson
@@ -134,6 +134,9 @@
         "wd:id":"Q326970"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"38fd84ce590243de9b138162c7a013a5",
     "wof:hierarchy":[
         {
@@ -144,7 +147,7 @@
         }
     ],
     "wof:id":101857877,
-    "wof:lastmodified":1566647362,
+    "wof:lastmodified":1582318743,
     "wof:name":"Vara\u017edin Breg",
     "wof:parent_id":85684835,
     "wof:placetype":"locality",

--- a/data/101/857/879/101857879.geojson
+++ b/data/101/857/879/101857879.geojson
@@ -92,6 +92,10 @@
         "wd:id":"Q847871"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"d55c59b49cac62727a1002f85038f7f6",
     "wof:hierarchy":[
         {
@@ -102,7 +106,7 @@
         }
     ],
     "wof:id":101857879,
-    "wof:lastmodified":1566647362,
+    "wof:lastmodified":1582318743,
     "wof:name":"Remetinec",
     "wof:parent_id":85684835,
     "wof:placetype":"locality",

--- a/data/101/858/919/101858919.geojson
+++ b/data/101/858/919/101858919.geojson
@@ -104,6 +104,9 @@
         "wk:page":"Donja Vo\u0107a"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"73420914e75e0233015b6eb31548dc5e",
     "wof:hierarchy":[
         {
@@ -117,7 +120,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647374,
+    "wof:lastmodified":1582318745,
     "wof:name":"Donja Vo\u0107a",
     "wof:parent_id":85684835,
     "wof:placetype":"locality",

--- a/data/101/858/921/101858921.geojson
+++ b/data/101/858/921/101858921.geojson
@@ -99,6 +99,9 @@
         "wk:page":"Kur\u0161anec"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"db2635c379af9c75b8e18ff4d742e011",
     "wof:hierarchy":[
         {
@@ -109,7 +112,7 @@
         }
     ],
     "wof:id":101858921,
-    "wof:lastmodified":1566647374,
+    "wof:lastmodified":1582318745,
     "wof:name":"Kur\u0161anec",
     "wof:parent_id":85684823,
     "wof:placetype":"locality",

--- a/data/101/874/225/101874225.geojson
+++ b/data/101/874/225/101874225.geojson
@@ -116,6 +116,9 @@
         "wk:page":"Du\u0107e"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b0b1056afea7643367e471eb7c4e0ee0",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":101874225,
-    "wof:lastmodified":1566647353,
+    "wof:lastmodified":1582318742,
     "wof:name":"Du\u0107e",
     "wof:parent_id":85684785,
     "wof:placetype":"locality",

--- a/data/101/874/227/101874227.geojson
+++ b/data/101/874/227/101874227.geojson
@@ -97,6 +97,10 @@
         "wk:page":"Brnaze"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9d1d47fa0e9a06466d083ba75f4e39e8",
     "wof:hierarchy":[
         {
@@ -107,7 +111,7 @@
         }
     ],
     "wof:id":101874227,
-    "wof:lastmodified":1566647352,
+    "wof:lastmodified":1582318742,
     "wof:name":"Brnaze",
     "wof:parent_id":85684781,
     "wof:placetype":"locality",

--- a/data/101/874/229/101874229.geojson
+++ b/data/101/874/229/101874229.geojson
@@ -182,6 +182,10 @@
         "wd:id":"Q397600"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"bd936f56a11d176b92fba98b51351322",
     "wof:hierarchy":[
         {
@@ -192,7 +196,7 @@
         }
     ],
     "wof:id":101874229,
-    "wof:lastmodified":1566647352,
+    "wof:lastmodified":1582318742,
     "wof:name":"Omi\u0161",
     "wof:parent_id":85684785,
     "wof:placetype":"locality",

--- a/data/101/874/233/101874233.geojson
+++ b/data/101/874/233/101874233.geojson
@@ -223,6 +223,10 @@
         "wd:id":"Q192119"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"c6cca279bf7ab3d74579315b69d180e8",
     "wof:hierarchy":[
         {
@@ -236,7 +240,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647353,
+    "wof:lastmodified":1582318742,
     "wof:name":"Sisak",
     "wof:parent_id":85684769,
     "wof:placetype":"locality",

--- a/data/101/874/235/101874235.geojson
+++ b/data/101/874/235/101874235.geojson
@@ -110,6 +110,10 @@
         "wk:page":"Strizivojna"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"032b13bcb5ca3feb7135eabbf81abb73",
     "wof:hierarchy":[
         {
@@ -123,7 +127,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566647352,
+    "wof:lastmodified":1582318742,
     "wof:name":"Strizivojna",
     "wof:parent_id":85684805,
     "wof:placetype":"locality",

--- a/data/101/874/237/101874237.geojson
+++ b/data/101/874/237/101874237.geojson
@@ -94,6 +94,10 @@
         "wk:page":"Ma\u010dkovec, Croatia"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f949ada9f5dc113cd8e2b4e3ac216434",
     "wof:hierarchy":[
         {
@@ -104,7 +108,7 @@
         }
     ],
     "wof:id":101874237,
-    "wof:lastmodified":1566647353,
+    "wof:lastmodified":1582318742,
     "wof:name":"Ma\u010dkovec",
     "wof:parent_id":85684823,
     "wof:placetype":"locality",

--- a/data/101/874/239/101874239.geojson
+++ b/data/101/874/239/101874239.geojson
@@ -90,6 +90,9 @@
         "wk:page":"Palovec"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b1d0fb521e61e68f026bb43d5a3ef32c",
     "wof:hierarchy":[
         {
@@ -100,7 +103,7 @@
         }
     ],
     "wof:id":101874239,
-    "wof:lastmodified":1566647353,
+    "wof:lastmodified":1582318742,
     "wof:name":"Palovec",
     "wof:parent_id":85684823,
     "wof:placetype":"locality",

--- a/data/101/874/241/101874241.geojson
+++ b/data/101/874/241/101874241.geojson
@@ -87,6 +87,10 @@
         "wd:id":"Q1209964"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"4c3eb6981fa4135799bab122a9f4fb9d",
     "wof:hierarchy":[
         {
@@ -97,7 +101,7 @@
         }
     ],
     "wof:id":101874241,
-    "wof:lastmodified":1566647353,
+    "wof:lastmodified":1582318742,
     "wof:name":"Mihovljan",
     "wof:parent_id":85684823,
     "wof:placetype":"locality",

--- a/data/101/910/957/101910957.geojson
+++ b/data/101/910/957/101910957.geojson
@@ -47,6 +47,9 @@
         "qs_pg:id":1088228
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"58a5a4f07c3b87596fb7bb4a22afca25",
     "wof:hierarchy":[
         {
@@ -57,7 +60,7 @@
         }
     ],
     "wof:id":101910957,
-    "wof:lastmodified":1566647422,
+    "wof:lastmodified":1582318753,
     "wof:name":"\u00c5 Imuni",
     "wof:parent_id":85684807,
     "wof:placetype":"locality",

--- a/data/101/911/001/101911001.geojson
+++ b/data/101/911/001/101911001.geojson
@@ -138,6 +138,9 @@
         "wk:page":"Pa\u0161man"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0a1da7e8da1d8f82bc8734bfac08c9f5",
     "wof:hierarchy":[
         {
@@ -148,7 +151,7 @@
         }
     ],
     "wof:id":101911001,
-    "wof:lastmodified":1566647422,
+    "wof:lastmodified":1582318753,
     "wof:name":"Pa\u00b5man",
     "wof:parent_id":85684807,
     "wof:placetype":"locality",

--- a/data/101/911/595/101911595.geojson
+++ b/data/101/911/595/101911595.geojson
@@ -98,6 +98,9 @@
         "wk:page":"Ora\u0161ac, Croatia"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e9fab33a8ebf3575edce24cedf7c2648",
     "wof:hierarchy":[
         {
@@ -108,7 +111,7 @@
         }
     ],
     "wof:id":101911595,
-    "wof:lastmodified":1566647422,
+    "wof:lastmodified":1582318753,
     "wof:name":"Ora\u00b5ac",
     "wof:parent_id":85684775,
     "wof:placetype":"locality",

--- a/data/101/911/597/101911597.geojson
+++ b/data/101/911/597/101911597.geojson
@@ -99,6 +99,9 @@
         "wk:page":"\u017divogo\u0161\u0107e"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"96f6478f1ece3efaceb5968372ac4276",
     "wof:hierarchy":[
         {
@@ -109,7 +112,7 @@
         }
     ],
     "wof:id":101911597,
-    "wof:lastmodified":1566647422,
+    "wof:lastmodified":1582318753,
     "wof:name":"\u017divogo\u0161\u0107e",
     "wof:parent_id":85684781,
     "wof:placetype":"locality",

--- a/data/101/912/511/101912511.geojson
+++ b/data/101/912/511/101912511.geojson
@@ -76,6 +76,9 @@
         "wd:id":"Q792190"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6883b2f5261106cdd8b93dc793582411",
     "wof:hierarchy":[
         {
@@ -86,7 +89,7 @@
         }
     ],
     "wof:id":101912511,
-    "wof:lastmodified":1566647377,
+    "wof:lastmodified":1582318746,
     "wof:name":"Belajske Poljice",
     "wof:parent_id":85684819,
     "wof:placetype":"locality",

--- a/data/101/912/585/101912585.geojson
+++ b/data/101/912/585/101912585.geojson
@@ -117,6 +117,9 @@
         "wd:id":"Q1781214"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"774d1b2551c2137ee3f413c426a82686",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":101912585,
-    "wof:lastmodified":1566647377,
+    "wof:lastmodified":1582318746,
     "wof:name":"Konavle",
     "wof:parent_id":85684775,
     "wof:placetype":"locality",

--- a/data/101/912/587/101912587.geojson
+++ b/data/101/912/587/101912587.geojson
@@ -95,6 +95,9 @@
         "qs_pg:id":1331646
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"cb1da967f80d7299a795b7f3cf92667a",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
         }
     ],
     "wof:id":101912587,
-    "wof:lastmodified":1566647377,
+    "wof:lastmodified":1582318746,
     "wof:name":"Punta Skala",
     "wof:parent_id":85684807,
     "wof:placetype":"locality",

--- a/data/856/332/29/85633229.geojson
+++ b/data/856/332/29/85633229.geojson
@@ -1125,6 +1125,11 @@
     },
     "wof:country":"HR",
     "wof:country_alpha3":"HRV",
+    "wof:geom_alt":[
+        "naturalearth",
+        "quattroshapes",
+        "naturalearth-display-terrestrial-zoom6"
+    ],
     "wof:geomhash":"977231104ed313da365d47c371ed12da",
     "wof:hierarchy":[
         {
@@ -1140,7 +1145,7 @@
         "hrv",
         "ita"
     ],
-    "wof:lastmodified":1566646757,
+    "wof:lastmodified":1582318729,
     "wof:name":"Croatia",
     "wof:parent_id":102191581,
     "wof:placetype":"country",

--- a/data/859/014/93/85901493.geojson
+++ b/data/859/014/93/85901493.geojson
@@ -107,6 +107,10 @@
         "wk:page":"\u010crnomerec"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"fbb0284ec3dda1744672efb66002f334",
     "wof:hierarchy":[
         {
@@ -121,7 +125,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566646756,
+    "wof:lastmodified":1582318728,
     "wof:name":"Crnomerec",
     "wof:parent_id":101751659,
     "wof:placetype":"neighbourhood",

--- a/data/859/014/95/85901495.geojson
+++ b/data/859/014/95/85901495.geojson
@@ -108,6 +108,10 @@
         "qs_pg:id":1349626
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"56138838569c6670b0d069755615205d",
     "wof:hierarchy":[
         {
@@ -122,7 +126,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566646756,
+    "wof:lastmodified":1582318728,
     "wof:name":"Donji Grad",
     "wof:parent_id":101751779,
     "wof:placetype":"neighbourhood",

--- a/data/859/014/97/85901497.geojson
+++ b/data/859/014/97/85901497.geojson
@@ -73,6 +73,10 @@
         "qs_pg:id":423445
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b2e2583a4a4311c1cc4f8f37d9d56e81",
     "wof:hierarchy":[
         {
@@ -87,7 +91,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566646756,
+    "wof:lastmodified":1582318728,
     "wof:name":"Donji Rukavac",
     "wof:parent_id":101758593,
     "wof:placetype":"neighbourhood",

--- a/data/859/015/01/85901501.geojson
+++ b/data/859/015/01/85901501.geojson
@@ -89,6 +89,9 @@
         "gp:id":847911
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e72b3e746fccbbca717ce38d6d5848c6",
     "wof:hierarchy":[
         {
@@ -103,7 +106,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566646756,
+    "wof:lastmodified":1582318728,
     "wof:name":"Gornji Grad",
     "wof:parent_id":101751779,
     "wof:placetype":"neighbourhood",

--- a/data/859/015/03/85901503.geojson
+++ b/data/859/015/03/85901503.geojson
@@ -124,6 +124,9 @@
         "wd:id":"Q1278569"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4d252f2fca667dc7aa98561078936235",
     "wof:hierarchy":[
         {
@@ -138,7 +141,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566646755,
+    "wof:lastmodified":1582318727,
     "wof:name":"Gornji grad",
     "wof:parent_id":101751659,
     "wof:placetype":"neighbourhood",

--- a/data/859/015/05/85901505.geojson
+++ b/data/859/015/05/85901505.geojson
@@ -68,6 +68,9 @@
         "gp:id":847951
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7111ba9d05e6c1fe394b93d1493da973",
     "wof:hierarchy":[
         {
@@ -82,7 +85,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566646755,
+    "wof:lastmodified":1582318727,
     "wof:name":"Gornji Rukavac",
     "wof:parent_id":101758587,
     "wof:placetype":"neighbourhood",

--- a/data/859/015/07/85901507.geojson
+++ b/data/859/015/07/85901507.geojson
@@ -110,6 +110,10 @@
         "wk:page":"Maksimir"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"dfa8c188e4430b2887271699870cca16",
     "wof:hierarchy":[
         {
@@ -124,7 +128,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566646756,
+    "wof:lastmodified":1582318727,
     "wof:name":"Maksimir",
     "wof:parent_id":101751659,
     "wof:placetype":"neighbourhood",

--- a/data/859/015/09/85901509.geojson
+++ b/data/859/015/09/85901509.geojson
@@ -106,6 +106,10 @@
         "wk:page":"Novi Zagreb"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"672631901e5799ad777902e4c93eaa80",
     "wof:hierarchy":[
         {
@@ -120,7 +124,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566646756,
+    "wof:lastmodified":1582318728,
     "wof:name":"Novi Zagreb",
     "wof:parent_id":101751659,
     "wof:placetype":"neighbourhood",

--- a/data/859/015/11/85901511.geojson
+++ b/data/859/015/11/85901511.geojson
@@ -152,6 +152,10 @@
         "wk:page":"Susak"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"78d85afd806ed14ded5f5189e7be013e",
     "wof:hierarchy":[
         {
@@ -166,7 +170,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566646755,
+    "wof:lastmodified":1582318727,
     "wof:name":"Su\u00b5ak",
     "wof:parent_id":101751775,
     "wof:placetype":"neighbourhood",

--- a/data/859/292/43/85929243.geojson
+++ b/data/859/292/43/85929243.geojson
@@ -114,6 +114,9 @@
         "wk:page":"Trnje, \u010cren\u0161ovci"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"59aa81f83ea50663303ae89b81add003",
     "wof:hierarchy":[
         {
@@ -128,7 +131,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566646756,
+    "wof:lastmodified":1582318728,
     "wof:name":"Trnje",
     "wof:parent_id":101751659,
     "wof:placetype":"neighbourhood",

--- a/data/859/292/47/85929247.geojson
+++ b/data/859/292/47/85929247.geojson
@@ -97,6 +97,10 @@
         "wd:id":"Q287296"
     },
     "wof:country":"HR",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"cf07d62fc72577ba4d7bf480868f7177",
     "wof:hierarchy":[
         {
@@ -111,7 +115,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566646756,
+    "wof:lastmodified":1582318728,
     "wof:name":"Podsused-Vrap\u010de",
     "wof:parent_id":101751659,
     "wof:placetype":"neighbourhood",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.