### PR TITLE
Name updates

### DIFF
--- a/data/856/332/29/85633229.geojson
+++ b/data/856/332/29/85633229.geojson
@@ -7,7 +7,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"1991-05~/1991-06~",
     "geom:area":6.438137,
-    "geom:area_square_m":56244397323.672325,
+    "geom:area_square_m":56244397292.120262,
     "geom:bbox":"13.490334,42.391224,19.447252,46.55502",
     "geom:latitude":45.042123,
     "geom:longitude":16.406103,
@@ -65,6 +65,9 @@
     "name:arg_x_preferred":[
         "Croacia"
     ],
+    "name:ary_x_preferred":[
+        "\u0643\u0631\u0648\u0627\u062a\u064a\u0627"
+    ],
     "name:arz_x_preferred":[
         "\u0643\u0631\u0648\u0627\u062a\u064a\u0627"
     ],
@@ -88,6 +91,9 @@
     ],
     "name:bam_x_preferred":[
         "Kroasi"
+    ],
+    "name:ban_x_preferred":[
+        "Kroasia"
     ],
     "name:bar_x_preferred":[
         "Krowozien"
@@ -188,6 +194,12 @@
     "name:dan_x_preferred":[
         "Kroatien"
     ],
+    "name:deu_at_x_preferred":[
+        "Kroatien"
+    ],
+    "name:deu_ch_x_preferred":[
+        "Kroatien"
+    ],
     "name:deu_x_preferred":[
         "Kroatien"
     ],
@@ -214,6 +226,12 @@
     ],
     "name:eml_x_preferred":[
         "Cru\u00e0sia"
+    ],
+    "name:eng_ca_x_preferred":[
+        "Croatia"
+    ],
+    "name:eng_gb_x_preferred":[
+        "Croatia"
     ],
     "name:eng_x_preferred":[
         "Croatia"
@@ -299,6 +317,9 @@
     "name:gan_x_preferred":[
         "\u514b\u7f57\u5730\u4e9a"
     ],
+    "name:gcr_x_preferred":[
+        "Kroasi"
+    ],
     "name:gla_x_preferred":[
         "Poblachd na Cr\u00f2thaise"
     ],
@@ -319,6 +340,9 @@
     ],
     "name:gom_x_preferred":[
         "\u0915\u094d\u0930\u094b\u090f\u0936\u093f\u092f\u093e"
+    ],
+    "name:got_x_preferred":[
+        "\ud800\udf3a\ud800\udf42\ud800\udf3f\ud800\udf45\ud800\udf30\ud800\udf44\ud800\udf43\ud800\udf3e\ud800\udf30"
     ],
     "name:grn_x_preferred":[
         "Kyoasia"
@@ -710,6 +734,9 @@
     "name:pol_x_preferred":[
         "Chorwacja"
     ],
+    "name:por_br_x_preferred":[
+        "Cro\u00e1cia"
+    ],
     "name:por_x_preferred":[
         "Cro\u00e1cia"
     ],
@@ -779,6 +806,9 @@
     "name:sna_x_variant":[
         "Korasia"
     ],
+    "name:snd_x_preferred":[
+        "\u06aa\u0631\u0648\u0634\u064a\u0627"
+    ],
     "name:som_x_preferred":[
         "Kroatia"
     ],
@@ -806,6 +836,12 @@
     "name:srn_x_preferred":[
         "Krvatkondre"
     ],
+    "name:srp_ec_x_preferred":[
+        "\u0425\u0440\u0432\u0430\u0442\u0441\u043a\u0430"
+    ],
+    "name:srp_el_x_preferred":[
+        "Hrvatska"
+    ],
     "name:srp_x_preferred":[
         "\u0425\u0440\u0432\u0430\u0442\u0441\u043a\u0430"
     ],
@@ -829,6 +865,9 @@
     ],
     "name:szl_x_preferred":[
         "Chorwacyjo"
+    ],
+    "name:szy_x_preferred":[
+        "Croatia"
     ],
     "name:tah_x_preferred":[
         "Toro\u0101tia"
@@ -974,8 +1013,26 @@
     "name:zha_x_preferred":[
         "Gwzlozdiya"
     ],
+    "name:zho_cn_x_preferred":[
+        "\u514b\u7f57\u5730\u4e9a"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u514b\u7f85\u5730\u4e9e"
+    ],
     "name:zho_min_nan_x_preferred":[
         "Hrvatska"
+    ],
+    "name:zho_mo_x_preferred":[
+        "\u514b\u7f85\u5730\u4e9e"
+    ],
+    "name:zho_my_x_preferred":[
+        "\u514b\u7f57\u5730\u4e9a"
+    ],
+    "name:zho_sg_x_preferred":[
+        "\u514b\u7f57\u5730\u4e9a"
+    ],
+    "name:zho_tw_x_preferred":[
+        "\u514b\u7f85\u57c3\u897f\u4e9e"
     ],
     "name:zho_x_preferred":[
         "\u514b\u7f57\u5730\u4e9a"
@@ -1146,7 +1203,7 @@
         "hrv",
         "ita"
     ],
-    "wof:lastmodified":1583797348,
+    "wof:lastmodified":1587427682,
     "wof:name":"Croatia",
     "wof:parent_id":102191581,
     "wof:placetype":"country",


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1796 and https://github.com/whosonfirst-data/whosonfirst-data/issues/1821.

This PR includes:
- Fixes to property values that start or end with `" "`, `\n`, or `\r`, removing those characters.
- Using a modified version of the [wiki names import script](https://github.com/whosonfirst/whosonfirst-cookbook/blob/master/scripts/crawl_to_add_wiki_names.py), adds new `name` properties

There will be ~260 similar PRs, one for each per-country repo. No PIP work require, can merge as-is.