### PR TITLE
wf concordances, placetype local, and more

### DIFF
--- a/data/856/332/29/85633229.geojson
+++ b/data/856/332/29/85633229.geojson
@@ -1313,6 +1313,7 @@
         "hasc:id":"HR",
         "icao:code":"9A",
         "ioc:id":"CRO",
+        "iso:code":"HR",
         "itu:id":"HRV",
         "loc:id":"n81035140",
         "m49:code":"191",
@@ -1327,6 +1328,7 @@
         "wk:page":"Croatia",
         "wmo:id":"RH"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"HR",
     "wof:country_alpha3":"HRV",
     "wof:created":1652212669,
@@ -1352,7 +1354,7 @@
         "hrv",
         "ita"
     ],
-    "wof:lastmodified":1694492253,
+    "wof:lastmodified":1695881366,
     "wof:name":"Croatia",
     "wof:parent_id":102191581,
     "wof:placetype":"country",

--- a/data/856/332/29/85633229.geojson
+++ b/data/856/332/29/85633229.geojson
@@ -25,6 +25,9 @@
     "itu:country_code":[
         "385"
     ],
+    "label:eng_x_preferred_placetype":[
+        "country"
+    ],
     "label:eng_x_preferred_shortcode":[
         "HR"
     ],
@@ -1334,7 +1337,7 @@
         "us-dshiu",
         "whosonfirst-interior"
     ],
-    "wof:geomhash":"7c2a3d4a052bba3e54268708599f09ea",
+    "wof:geomhash":"47bd37ee956dfc66de5f7888b1c9aaf5",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -1349,7 +1352,7 @@
         "hrv",
         "ita"
     ],
-    "wof:lastmodified":1690930365,
+    "wof:lastmodified":1694492253,
     "wof:name":"Croatia",
     "wof:parent_id":102191581,
     "wof:placetype":"country",

--- a/data/856/847/33/85684733.geojson
+++ b/data/856/847/33/85684733.geojson
@@ -381,12 +381,18 @@
         "gn:id":3337529,
         "gp:id":12577988,
         "hasc:id":"HR.VS",
+        "iso:code":"HR-16",
         "iso:id":"HR-16",
+        "qs:local_id":"16",
         "unlc:id":"HR-16",
         "wd:id":"Q58225"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"HR",
-    "wof:geomhash":"18f13c737b38bd2ebb65d3660cb15cab",
+    "wof:geomhash":"f1c917c0ecd17a9f56ccc7efe8f8cd50",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -402,7 +408,7 @@
         "hrv",
         "ita"
     ],
-    "wof:lastmodified":1690930369,
+    "wof:lastmodified":1695885269,
     "wof:name":"Vukovarsko-srijemska",
     "wof:parent_id":85633229,
     "wof:placetype":"region",

--- a/data/856/847/37/85684737.geojson
+++ b/data/856/847/37/85684737.geojson
@@ -390,12 +390,18 @@
         "gn:id":3337520,
         "gp:id":12577978,
         "hasc:id":"HR.LS",
+        "iso:code":"HR-09",
         "iso:id":"HR-09",
+        "qs:local_id":"09",
         "unlc:id":"HR-09",
         "wd:id":"Q58081"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"HR",
-    "wof:geomhash":"1e558e35a2c0428b5e5f5320d890002f",
+    "wof:geomhash":"287db54bcb05ca4087d7cc32a6b79954",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -411,7 +417,7 @@
         "hrv",
         "ita"
     ],
-    "wof:lastmodified":1690930371,
+    "wof:lastmodified":1695885269,
     "wof:name":"Licko-senjska",
     "wof:parent_id":85633229,
     "wof:placetype":"region",

--- a/data/856/847/41/85684741.geojson
+++ b/data/856/847/41/85684741.geojson
@@ -19,7 +19,7 @@
     "mps:latitude":45.513265,
     "mps:longitude":13.374041,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":9.0,
     "name:deu_x_preferred":[
@@ -46,7 +46,14 @@
         85633229
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "iso:code_pseudo":"HR-XX1",
+        "qs:a1_lc_pseudo":"X1"
+    },
+    "wof:concordances_official":"qs:a1_lc_pseudo",
+    "wof:concordances_official_alt":[
+        "iso:code_pseudo"
+    ],
     "wof:country":"HR",
     "wof:geomhash":"93a8c491729dc03337c66c851d78fe4a",
     "wof:hierarchy":[
@@ -69,7 +76,7 @@
         "hrv",
         "ita"
     ],
-    "wof:lastmodified":1694493126,
+    "wof:lastmodified":1695884283,
     "wof:name":"Disputed areas of Croatia",
     "wof:parent_id":85633229,
     "wof:placetype":"region",

--- a/data/856/847/41/85684741.geojson
+++ b/data/856/847/41/85684741.geojson
@@ -5,11 +5,14 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.040846,
-    "geom:area_square_m":353650446.831525,
+    "geom:area_square_m":353651656.372956,
     "geom:bbox":"13.210449,44.901058,19.443134,45.921398",
     "geom:latitude":45.555456,
     "geom:longitude":15.287663,
     "iso:country":"HR",
+    "label:eng_x_preferred_placetype":[
+        "disputed"
+    ],
     "lbl:latitude":45.513265,
     "lbl:longitude":13.374041,
     "lbl:min_zoom":8.0,
@@ -45,7 +48,7 @@
     "wof:breaches":[],
     "wof:concordances":{},
     "wof:country":"HR",
-    "wof:geomhash":"837c84feace95d37580e63ec838b5a83",
+    "wof:geomhash":"93a8c491729dc03337c66c851d78fe4a",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -66,7 +69,7 @@
         "hrv",
         "ita"
     ],
-    "wof:lastmodified":1627522188,
+    "wof:lastmodified":1694493126,
     "wof:name":"Disputed areas of Croatia",
     "wof:parent_id":85633229,
     "wof:placetype":"region",

--- a/data/856/847/49/85684749.geojson
+++ b/data/856/847/49/85684749.geojson
@@ -316,12 +316,18 @@
         "eurostat:nuts_2021_id":"HR024",
         "fips:code":"HR02",
         "hasc:id":"HR.SP",
+        "iso:code":"HR-12",
         "iso:id":"HR-12",
+        "qs:local_id":"12",
         "unlc:id":"HR-12",
         "wd:id":"Q58129"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"HR",
-    "wof:geomhash":"efaf1384c8f24b8f84d736a20adbe580",
+    "wof:geomhash":"2aef50ee73a68af487231e558b247d6f",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -337,7 +343,7 @@
         "hrv",
         "ita"
     ],
-    "wof:lastmodified":1690930372,
+    "wof:lastmodified":1695885269,
     "wof:name":"Brodsko-posavska",
     "wof:parent_id":85633229,
     "wof:placetype":"region",

--- a/data/856/847/53/85684753.geojson
+++ b/data/856/847/53/85684753.geojson
@@ -394,12 +394,18 @@
         "gn:id":3337511,
         "gp:id":12577991,
         "hasc:id":"HR.BB",
+        "iso:code":"HR-07",
         "iso:id":"HR-07",
+        "qs:local_id":"07",
         "unlc:id":"HR-07",
         "wd:id":"Q58060"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"HR",
-    "wof:geomhash":"6e506d88ef0cbc1c0817cb2be8cbd242",
+    "wof:geomhash":"b31c2879b404f668e98a7c6ee7be1865",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -415,7 +421,7 @@
         "hrv",
         "ita"
     ],
-    "wof:lastmodified":1690930371,
+    "wof:lastmodified":1695885269,
     "wof:name":"Bjelovarsko-bilogorska",
     "wof:parent_id":85633229,
     "wof:placetype":"region",

--- a/data/856/847/55/85684755.geojson
+++ b/data/856/847/55/85684755.geojson
@@ -381,12 +381,18 @@
         "gn:id":3337525,
         "gp:id":12577983,
         "hasc:id":"HR.SB",
+        "iso:code":"HR-15",
         "iso:id":"HR-15",
+        "qs:local_id":"15",
         "unlc:id":"HR-15",
         "wd:id":"Q58194"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"HR",
-    "wof:geomhash":"4c39bac0e64d75a1825769f5ba1508b1",
+    "wof:geomhash":"96f0dd40d1f3b820f731cac5ee545eeb",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -402,7 +408,7 @@
         "hrv",
         "ita"
     ],
-    "wof:lastmodified":1690930372,
+    "wof:lastmodified":1695885269,
     "wof:name":"\u0160ibensko-kninska",
     "wof:parent_id":85633229,
     "wof:placetype":"region",

--- a/data/856/847/63/85684763.geojson
+++ b/data/856/847/63/85684763.geojson
@@ -290,12 +290,18 @@
         "eurostat:nuts_2021_id":"HR023",
         "fips:code":"HR11",
         "hasc:id":"HR.PS",
+        "iso:code":"HR-11",
         "iso:id":"HR-11",
+        "qs:local_id":"11",
         "unlc:id":"HR-11",
         "wd:id":"Q58111"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"HR",
-    "wof:geomhash":"efecd2b4874952ba7c500d0766cb31de",
+    "wof:geomhash":"8ad1afba8bcaec209f048b58cd3902cb",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -311,7 +317,7 @@
         "hrv",
         "ita"
     ],
-    "wof:lastmodified":1690930372,
+    "wof:lastmodified":1695885269,
     "wof:name":"Po\u017ee\u0161ko-slavonska",
     "wof:parent_id":85633229,
     "wof:placetype":"region",

--- a/data/856/847/65/85684765.geojson
+++ b/data/856/847/65/85684765.geojson
@@ -405,12 +405,18 @@
         "gn:id":3337531,
         "gp:id":12577990,
         "hasc:id":"HR.ZG",
+        "iso:code":"HR-01",
         "iso:id":"HR-01",
+        "qs:local_id":"01",
         "unlc:id":"HR-01",
         "wd:id":"Q27038"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"HR",
-    "wof:geomhash":"d3ec333815f1045667efade5e9395fc4",
+    "wof:geomhash":"c1bde506fd29399cd362e70288a5c753",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -426,7 +432,7 @@
         "hrv",
         "ita"
     ],
-    "wof:lastmodified":1690930370,
+    "wof:lastmodified":1695885269,
     "wof:name":"Zagrebacka",
     "wof:parent_id":85633229,
     "wof:placetype":"region",

--- a/data/856/847/69/85684769.geojson
+++ b/data/856/847/69/85684769.geojson
@@ -381,12 +381,18 @@
         "gn:id":3337526,
         "gp:id":12577984,
         "hasc:id":"HR.SM",
+        "iso:code":"HR-03",
         "iso:id":"HR-03",
+        "qs:local_id":"03",
         "unlc:id":"HR-03",
         "wd:id":"Q57060"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"HR",
-    "wof:geomhash":"01f641adfe8a723f25464293fe1a4f23",
+    "wof:geomhash":"78e72f6f3dc90ed169c2bf1457c20cfd",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -402,7 +408,7 @@
         "hrv",
         "ita"
     ],
-    "wof:lastmodified":1690930368,
+    "wof:lastmodified":1695885269,
     "wof:name":"Sisacko-moslavacka",
     "wof:parent_id":85633229,
     "wof:placetype":"region",

--- a/data/856/847/75/85684775.geojson
+++ b/data/856/847/75/85684775.geojson
@@ -394,12 +394,18 @@
         "gn:id":3337513,
         "gp:id":12577973,
         "hasc:id":"HR.DN",
+        "iso:code":"HR-19",
         "iso:id":"HR-19",
+        "qs:local_id":"19",
         "unlc:id":"HR-19",
         "wd:id":"Q58289"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"HR",
-    "wof:geomhash":"c60996469655c4c22e71e1527b08b299",
+    "wof:geomhash":"4288c141a695b726a8973823d94ec23d",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -415,7 +421,7 @@
         "hrv",
         "ita"
     ],
-    "wof:lastmodified":1690930369,
+    "wof:lastmodified":1695885269,
     "wof:name":"Dubrovacko-neretvanska",
     "wof:parent_id":85633229,
     "wof:placetype":"region",

--- a/data/856/847/81/85684781.geojson
+++ b/data/856/847/81/85684781.geojson
@@ -385,12 +385,18 @@
         "gn:id":3337527,
         "gp:id":12577985,
         "hasc:id":"HR.SD",
+        "iso:code":"HR-17",
         "iso:id":"HR-17",
+        "qs:local_id":"17",
         "unlc:id":"HR-17",
         "wd:id":"Q58253"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"HR",
-    "wof:geomhash":"2cd7db383393f940227895c42322817c",
+    "wof:geomhash":"93a7cdf80f170acc058961c9754c6d73",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -406,7 +412,7 @@
         "hrv",
         "ita"
     ],
-    "wof:lastmodified":1690930370,
+    "wof:lastmodified":1695885269,
     "wof:name":"Splitsko-dalmatinska",
     "wof:parent_id":85633229,
     "wof:placetype":"region",

--- a/data/856/847/85/85684785.geojson
+++ b/data/856/847/85/85684785.geojson
@@ -46,7 +46,14 @@
         85633229
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "iso:code_pseudo":"HR-XX2",
+        "qs:a1_lc_pseudo":"X2"
+    },
+    "wof:concordances_official":"qs:a1_lc_pseudo",
+    "wof:concordances_official_alt":[
+        "iso:code_pseudo"
+    ],
     "wof:country":"HR",
     "wof:geomhash":"f2bf1461cf16feb023305a91632fe2db",
     "wof:hierarchy":[
@@ -64,7 +71,7 @@
         "hrv",
         "ita"
     ],
-    "wof:lastmodified":1694493126,
+    "wof:lastmodified":1695884283,
     "wof:name":"Inland waters of Croatia",
     "wof:parent_id":85633229,
     "wof:placetype":"region",

--- a/data/856/847/85/85684785.geojson
+++ b/data/856/847/85/85684785.geojson
@@ -5,18 +5,21 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.49691,
-    "geom:area_square_m":31299923832.96487,
+    "geom:area_square_m":31299925102.625298,
     "geom:bbox":"13.224042,42.175899,18.54157,45.503066",
     "geom:latitude":43.618249,
     "geom:longitude":15.646464,
     "iso:country":"HR",
+    "label:eng_x_preferred_placetype":[
+        "territorial waters"
+    ],
     "lbl:latitude":43.025262,
     "lbl:longitude":15.684721,
     "lbl:min_zoom":8.0,
     "mps:latitude":43.025262,
     "mps:longitude":15.684721,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":18.0,
     "mz:min_zoom":18.0,
     "name:deu_x_preferred":[
@@ -45,7 +48,7 @@
     "wof:breaches":[],
     "wof:concordances":{},
     "wof:country":"HR",
-    "wof:geomhash":"03e621daba792c21556eb27e45355909",
+    "wof:geomhash":"f2bf1461cf16feb023305a91632fe2db",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -61,7 +64,7 @@
         "hrv",
         "ita"
     ],
-    "wof:lastmodified":1627522189,
+    "wof:lastmodified":1694493126,
     "wof:name":"Inland waters of Croatia",
     "wof:parent_id":85633229,
     "wof:placetype":"region",

--- a/data/856/847/89/85684789.geojson
+++ b/data/856/847/89/85684789.geojson
@@ -377,12 +377,18 @@
         "gn:id":3337524,
         "gp:id":12577982,
         "hasc:id":"HR.PG",
+        "iso:code":"HR-08",
         "iso:id":"HR-08",
+        "qs:local_id":"08",
         "unlc:id":"HR-08",
         "wd:id":"Q58071"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"HR",
-    "wof:geomhash":"fad4309c59e31977616d29fb4e0a1029",
+    "wof:geomhash":"9f082557f7b3a6440aa9ff457c25b864",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -398,7 +404,7 @@
         "hrv",
         "ita"
     ],
-    "wof:lastmodified":1690930369,
+    "wof:lastmodified":1695885270,
     "wof:name":"Primorsko-goranska",
     "wof:parent_id":85633229,
     "wof:placetype":"region",

--- a/data/856/847/93/85684793.geojson
+++ b/data/856/847/93/85684793.geojson
@@ -363,12 +363,18 @@
         "gn:id":3337533,
         "gp:id":12577987,
         "hasc:id":"HR.VP",
+        "iso:code":"HR-10",
         "iso:id":"HR-10",
+        "qs:local_id":"10",
         "unlc:id":"HR-10",
         "wd:id":"Q58092"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"HR",
-    "wof:geomhash":"c45ed0839b5fa66bcbdb45e62d7224fe",
+    "wof:geomhash":"076717254c02c3ca8d55aca0db822689",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -384,7 +390,7 @@
         "hrv",
         "ita"
     ],
-    "wof:lastmodified":1690930368,
+    "wof:lastmodified":1695885270,
     "wof:name":"Viroviticko-podravska",
     "wof:parent_id":85633229,
     "wof:placetype":"region",

--- a/data/856/847/99/85684799.geojson
+++ b/data/856/847/99/85684799.geojson
@@ -362,12 +362,18 @@
         "gn:id":3337518,
         "gp:id":12577976,
         "hasc:id":"HR.KK",
+        "iso:code":"HR-06",
         "iso:id":"HR-06",
+        "qs:local_id":"06",
         "unlc:id":"HR-06",
         "wd:id":"Q58026"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"HR",
-    "wof:geomhash":"55a14dfcc40488ca1f279c29331a63a8",
+    "wof:geomhash":"b99cbf19976d5cc29665015e7bdcb4bc",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -383,7 +389,7 @@
         "hrv",
         "ita"
     ],
-    "wof:lastmodified":1690930371,
+    "wof:lastmodified":1695885270,
     "wof:name":"Koprivnicko-kri\u017eevacka",
     "wof:parent_id":85633229,
     "wof:placetype":"region",

--- a/data/856/848/05/85684805.geojson
+++ b/data/856/848/05/85684805.geojson
@@ -381,12 +381,18 @@
         "gn:id":3337522,
         "gp:id":12577980,
         "hasc:id":"HR.OB",
+        "iso:code":"HR-14",
         "iso:id":"HR-14",
+        "qs:local_id":"14",
         "unlc:id":"HR-14",
         "wd:id":"Q58159"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"HR",
-    "wof:geomhash":"45c6969ccd0dffcc84215dd7377ec8a8",
+    "wof:geomhash":"52636e31fe52fa07f881dae75509f620",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -402,7 +408,7 @@
         "hrv",
         "ita"
     ],
-    "wof:lastmodified":1690930366,
+    "wof:lastmodified":1695885270,
     "wof:name":"Osjecko-baranjska",
     "wof:parent_id":85633229,
     "wof:placetype":"region",

--- a/data/856/848/07/85684807.geojson
+++ b/data/856/848/07/85684807.geojson
@@ -27,6 +27,9 @@
     "label:eng_x_preferred_longname":[
         "Zadarska County"
     ],
+    "label:eng_x_preferred_placetype":[
+        "county"
+    ],
     "label:eng_x_preferred_shortcode":[
         "ZD"
     ],
@@ -384,7 +387,7 @@
         "wd:id":"Q58146"
     },
     "wof:country":"HR",
-    "wof:geomhash":"c11cae7ed369044b1445a97c0275992e",
+    "wof:geomhash":"64843a9fefdfa316ddf3223cca0b5129",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -400,7 +403,7 @@
         "hrv",
         "ita"
     ],
-    "wof:lastmodified":1690930367,
+    "wof:lastmodified":1694493292,
     "wof:name":"Zadarska",
     "wof:parent_id":85633229,
     "wof:placetype":"region",

--- a/data/856/848/07/85684807.geojson
+++ b/data/856/848/07/85684807.geojson
@@ -383,9 +383,15 @@
         "gn:id":3337530,
         "gp:id":12577989,
         "hasc:id":"HR.ZD",
+        "iso:code":"HR-13",
+        "qs:local_id":"13",
         "unlc:id":"HR-13",
         "wd:id":"Q58146"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"HR",
     "wof:geomhash":"64843a9fefdfa316ddf3223cca0b5129",
     "wof:hierarchy":[
@@ -403,7 +409,7 @@
         "hrv",
         "ita"
     ],
-    "wof:lastmodified":1694493292,
+    "wof:lastmodified":1695885270,
     "wof:name":"Zadarska",
     "wof:parent_id":85633229,
     "wof:placetype":"region",

--- a/data/856/848/11/85684811.geojson
+++ b/data/856/848/11/85684811.geojson
@@ -388,12 +388,18 @@
         "gn:id":3337532,
         "gp:id":20070170,
         "hasc:id":"HR.GZ",
+        "iso:code":"HR-21",
         "iso:id":"HR-21",
+        "qs:local_id":"21",
         "unlc:id":"HR-21",
         "wd:id":"Q27038"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"HR",
-    "wof:geomhash":"58ac2e9b56149cd95ae5eb6a9e37309a",
+    "wof:geomhash":"7baf51b7d445f6f4cf42421d31e58151",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -409,7 +415,7 @@
         "hrv",
         "ita"
     ],
-    "wof:lastmodified":1690930366,
+    "wof:lastmodified":1695885270,
     "wof:name":"Grad Zagreb",
     "wof:parent_id":85633229,
     "wof:placetype":"region",

--- a/data/856/848/13/85684813.geojson
+++ b/data/856/848/13/85684813.geojson
@@ -372,12 +372,18 @@
         "gn:id":3337519,
         "gp:id":12577977,
         "hasc:id":"HR.KZ",
+        "iso:code":"HR-02",
         "iso:id":"HR-02",
+        "qs:local_id":"02",
         "unlc:id":"HR-02",
         "wd:id":"Q57056"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"HR",
-    "wof:geomhash":"b8d19a6810f46d034af26baca54e746a",
+    "wof:geomhash":"5e52c42fbd4a272215ca312bc0548684",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -393,7 +399,7 @@
         "hrv",
         "ita"
     ],
-    "wof:lastmodified":1690930368,
+    "wof:lastmodified":1695885270,
     "wof:name":"Krapinsko-zagorska",
     "wof:parent_id":85633229,
     "wof:placetype":"region",

--- a/data/856/848/19/85684819.geojson
+++ b/data/856/848/19/85684819.geojson
@@ -399,12 +399,18 @@
         "gn:id":3337515,
         "gp:id":12577975,
         "hasc:id":"HR.KA",
+        "iso:code":"HR-04",
         "iso:id":"HR-04",
+        "qs:local_id":"04",
         "unlc:id":"HR-04",
         "wd:id":"Q57071"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"HR",
-    "wof:geomhash":"951c6f3c12189e53108513809910ee2a",
+    "wof:geomhash":"530404387b0ed91ed5fc3a4945746e86",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -420,7 +426,7 @@
         "hrv",
         "ita"
     ],
-    "wof:lastmodified":1690930367,
+    "wof:lastmodified":1695885270,
     "wof:name":"Karlovacka",
     "wof:parent_id":85633229,
     "wof:placetype":"region",

--- a/data/856/848/23/85684823.geojson
+++ b/data/856/848/23/85684823.geojson
@@ -369,12 +369,18 @@
         "gn:id":3337521,
         "gp:id":12577979,
         "hasc:id":"HR.ME",
+        "iso:code":"HR-20",
         "iso:id":"HR-20",
+        "qs:local_id":"20",
         "unlc:id":"HR-20",
         "wd:id":"Q58330"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"HR",
-    "wof:geomhash":"bd51dd4abdeda1e760ed93c93d2ad4d0",
+    "wof:geomhash":"0d0a7d90b5b9574469908bc8eb0db5c1",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -390,7 +396,7 @@
         "hrv",
         "ita"
     ],
-    "wof:lastmodified":1690930367,
+    "wof:lastmodified":1695885270,
     "wof:name":"Medimurska",
     "wof:parent_id":85633229,
     "wof:placetype":"region",

--- a/data/856/848/29/85684829.geojson
+++ b/data/856/848/29/85684829.geojson
@@ -395,12 +395,18 @@
         "gn:id":3337514,
         "gp:id":12577974,
         "hasc:id":"HR.IS",
+        "iso:code":"HR-18",
         "iso:id":"HR-18",
+        "qs:local_id":"18",
         "unlc:id":"HR-18",
         "wd:id":"Q58268"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"HR",
-    "wof:geomhash":"6ea6c77395c5d3348db6097b22e0dbe5",
+    "wof:geomhash":"e2b391eda3900bd9795f5feeeb6db62a",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -416,7 +422,7 @@
         "hrv",
         "ita"
     ],
-    "wof:lastmodified":1690930366,
+    "wof:lastmodified":1695885270,
     "wof:name":"Istarska",
     "wof:parent_id":85633229,
     "wof:placetype":"region",

--- a/data/856/848/35/85684835.geojson
+++ b/data/856/848/35/85684835.geojson
@@ -365,12 +365,18 @@
         "gn:id":3337528,
         "gp:id":12577986,
         "hasc:id":"HR.VA",
+        "iso:code":"HR-05",
         "iso:id":"HR-05",
+        "qs:local_id":"05",
         "unlc:id":"HR-05",
         "wd:id":"Q57967"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"HR",
-    "wof:geomhash":"f0e6935a839d4e23e3489cc126b3bd4e",
+    "wof:geomhash":"dba5df1d71c95f2161b617bdbee6c449",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -386,7 +392,7 @@
         "hrv",
         "ita"
     ],
-    "wof:lastmodified":1690930365,
+    "wof:lastmodified":1695885271,
     "wof:name":"Vara\u017edinska",
     "wof:parent_id":85633229,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.